### PR TITLE
add minor topic remapping

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,5 +4,6 @@ PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/encode.hpp
     ${CMAKE_CURRENT_LIST_DIR}/decode.hpp
     ${CMAKE_CURRENT_LIST_DIR}/WsClient.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/WebVizConstants.hpp
     ${CMAKE_CURRENT_LIST_DIR}/RosClientNode.hpp
 )

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -39,8 +39,6 @@ class RosClientNode : public QObject {
   void encode_ros_msg(
       const T& msg, const std::string& msg_type,
       const std::string& to_topic) {
-    std::cerr << "encoding " << msg_type << " message to " << to_topic
-              << std::endl;
 
     flatbuffers::FlatBufferBuilder fbb;
     encode<T>(fbb, msg, msg_type, to_topic);

--- a/src/WebVizConstants.hpp
+++ b/src/WebVizConstants.hpp
@@ -1,0 +1,11 @@
+#include <string>
+
+namespace webviz_constants {
+static const std::string status_topic = "status";
+static const std::string subscription_topic = "subscriptions";
+static const std::string localization_topic = "localization";
+static const std::string odometry_topic = "odometry/raw";
+static const std::string lidar_2d_topic = "velodyne_2dscan";
+static const std::string left_image_topic = "stereo/left/image_raw/compressed";
+static const std::string right_image_topic = "stereo/right/image_raw/compressed";
+}

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -12,18 +12,31 @@
 #include "RosClientNode.hpp"
 
 namespace config {
-static const std::string host_url = "ws://localhost:8080";
+static const std::string host_url = "wss://10.0.0.1:8080";
 static const std::string ros_node_name = "robofleet_client";
+static const std::string robot_name = "robot";
 
+// Edit the configuration here to provide the correct topic names.
+static const std::string status_topic = "status";
+static const std::string subscription_topic = "subscriptions";
+static const std::string localization_topic = "localization";
+static const std::string odometry_topic = "odometry/raw";
+static const std::string lidar_2d_topic = "velodyne_2dscan";
+static const std::string left_image_topic = "stereo/left/image_raw/compressed";
+static const std::string right_image_topic = "stereo/right/image_raw/compressed";
+
+// All message types and subscribed topics must be enumerated here.
+// Specializations must also be provided in encode.hpp and decode.hpp
 static void configure_msg_types(RosClientNode& cn) {
-  // All message types and subscribed topics must be enumerated here.
-  // Specializations must also be provided in encode.hpp and decode.hpp
-  cn.register_msg_type<amrl_msgs::RobofleetStatus>("status");
-  cn.register_msg_type<amrl_msgs::RobofleetSubscription>("subscriptions");
-  cn.register_msg_type<amrl_msgs::Localization2DMsg>("localization");
-  cn.register_msg_type<nav_msgs::Odometry>("odometry/raw");
-  cn.register_msg_type<sensor_msgs::LaserScan>("velodyne_2dscan");
-  cn.register_msg_type<sensor_msgs::CompressedImage>(
-      "stereo/left/image_raw/compressed");
+  // These topics are used by webviz. Do not modify this section of the config
+  cn.register_msg_type<amrl_msgs::RobofleetStatus>(status_topic, robot_name + "/" + "status");
+  cn.register_msg_type<amrl_msgs::RobofleetSubscription>(subscription_topic, robot_name + "/" + "subscriptions");
+  cn.register_msg_type<amrl_msgs::Localization2DMsg>(localization_topic, robot_name + "/" + "localization");
+  cn.register_msg_type<nav_msgs::Odometry>(odometry_topic, robot_name + "/" + "odometry/raw");
+  cn.register_msg_type<sensor_msgs::LaserScan>(lidar_2d_topic, robot_name + "/" + "velodyne_2dscan");
+  cn.register_msg_type<sensor_msgs::CompressedImage>(left_image_topic, robot_name +  "/" +"stereo/left/image_raw/compressed");
+  cn.register_msg_type<sensor_msgs::CompressedImage>(right_image_topic, robot_name +  "/" +"stereo/right/image_raw/compressed");
+
+  // Add additional topics to subscribe and publish here.
 }
 }  // namespace config

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -10,13 +10,14 @@
 #include <string>
 
 #include "RosClientNode.hpp"
+#include "WebVizConstants.hpp"
 
 namespace config {
-static const std::string host_url = "wss://10.0.0.1:8080";
+static const std::string host_url = "ws://localhost:8080"; // wss://10.0.0.1:8080
 static const std::string ros_node_name = "robofleet_client";
-static const std::string robot_name = "robot";
 
 // Edit the configuration here to provide the correct topic names.
+// Reminder: Adding a leading `/` will make these topics absolute, meaning they won't be prepended the current ROS_NAMESPACE
 static const std::string status_topic = "status";
 static const std::string subscription_topic = "subscriptions";
 static const std::string localization_topic = "localization";
@@ -27,15 +28,17 @@ static const std::string right_image_topic = "stereo/right/image_raw/compressed"
 
 // All message types and subscribed topics must be enumerated here.
 // Specializations must also be provided in encode.hpp and decode.hpp
+
 static void configure_msg_types(RosClientNode& cn) {
   // These topics are used by webviz. Do not modify this section of the config
-  cn.register_msg_type<amrl_msgs::RobofleetStatus>(status_topic, robot_name + "/" + "status");
-  cn.register_msg_type<amrl_msgs::RobofleetSubscription>(subscription_topic, robot_name + "/" + "subscriptions");
-  cn.register_msg_type<amrl_msgs::Localization2DMsg>(localization_topic, robot_name + "/" + "localization");
-  cn.register_msg_type<nav_msgs::Odometry>(odometry_topic, robot_name + "/" + "odometry/raw");
-  cn.register_msg_type<sensor_msgs::LaserScan>(lidar_2d_topic, robot_name + "/" + "velodyne_2dscan");
-  cn.register_msg_type<sensor_msgs::CompressedImage>(left_image_topic, robot_name +  "/" +"stereo/left/image_raw/compressed");
-  cn.register_msg_type<sensor_msgs::CompressedImage>(right_image_topic, robot_name +  "/" +"stereo/right/image_raw/compressed");
+  // The output topics are relative, and so will always be namespaced
+  cn.register_msg_type<amrl_msgs::RobofleetStatus>(status_topic, webviz_constants::status_topic);
+  cn.register_msg_type<amrl_msgs::RobofleetSubscription>(subscription_topic, webviz_constants::subscription_topic);
+  cn.register_msg_type<amrl_msgs::Localization2DMsg>(localization_topic, webviz_constants::localization_topic);
+  cn.register_msg_type<nav_msgs::Odometry>(odometry_topic,  webviz_constants::odometry_topic);
+  cn.register_msg_type<sensor_msgs::LaserScan>(lidar_2d_topic,  webviz_constants::lidar_2d_topic);
+  cn.register_msg_type<sensor_msgs::CompressedImage>(left_image_topic, webviz_constants::left_image_topic);
+  cn.register_msg_type<sensor_msgs::CompressedImage>(right_image_topic, webviz_constants::right_image_topic);
 
   // Add additional topics to subscribe and publish here.
 }


### PR DESCRIPTION
overview is that now the config file registers both the from_topic and to_topic.

Also, in the place of namespacing (which we can still support, but for now seems too idealistic), we now have a `robot_name` in the config, which gets prefixed before the final output topics.