### PR TITLE
Kavan/auto subscribe

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,5 @@ BinPackArguments: false
 AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
-AllowShortLambdasOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 ---

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -93,10 +93,9 @@ class RosClientNode : public QObject {
   }
 
   /**
-   * @brief Attempt to decode an publish message data.
-   *
-   * Must call register_msg_type<T> before a message of type T can be decoded.
-   * @param data the Flatbuffer-encoded message data
+   * @brief subscribe to remote messages that were specified in the config by
+   * calling register_remote_msg_type. This function should run once a websocket
+   * connection has been established
    */
   void subscribe_remote_msgs() {
     for (auto topic : pub_remote_topics) {
@@ -151,7 +150,8 @@ class RosClientNode : public QObject {
   }
 
   /**
-   * @brief Set up pub/sub for a particular message type and topic.
+   * @brief Set up remote publishing for a particular message type and topic
+   * sent from the server.
    *
    * Sets up the client to publish to `to_topic` whenever it
    * recieves a message of type `from_topic` from the remote server.

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -48,11 +48,12 @@ class RosClientNode : public QObject {
   }
 
   template <typename T>
-  void publish_ros_msg(const T& msg, const std::string& msg_type, const std::string& to_topic) {
+  void publish_ros_msg(
+      const T& msg, const std::string& msg_type, const std::string& to_topic) {
     if (pubs.count(msg_type) == 0) {
       // gotcha: it's important that we only publish one type T for any given
-      // msg_type! register_msg_type() handles this by checking for duplicate msg_type
-      // registrations.
+      // msg_type! register_msg_type() handles this by checking for duplicate
+      // msg_type registrations.
       pubs[msg_type] = n.advertise<T>(to_topic, 1);
     }
 
@@ -98,12 +99,16 @@ class RosClientNode : public QObject {
    * @param data the Flatbuffer-encoded message data
    */
   void subscribe_remote_msgs() {
-    for(auto topic : pub_remote_topics) {
+    for (auto topic : pub_remote_topics) {
       // Now, subscribe to the appropriate remote message
       amrl_msgs::RobofleetSubscription sub_msg;
       sub_msg.action = amrl_msgs::RobofleetSubscription::ACTION_SUBSCRIBE;
       sub_msg.topic_regex = topic;
-      encode_ros_msg<amrl_msgs::RobofleetSubscription>(sub_msg, ros::message_traits::DataType<amrl_msgs::RobofleetSubscription>().value(), "/subscriptions");
+      encode_ros_msg<amrl_msgs::RobofleetSubscription>(
+          sub_msg,
+          ros::message_traits::DataType<amrl_msgs::RobofleetSubscription>()
+              .value(),
+          "/subscriptions");
     }
   }
 
@@ -164,22 +169,24 @@ class RosClientNode : public QObject {
 
     if (subs.count(full_to_topic) > 0) {
       throw std::runtime_error(
-          "Trying to publish to a topic that is registered as a subscription. This can create infinite feedback loops and is not allowed.");
+          "Trying to publish to a topic that is registered as a subscription. "
+          "This can create infinite feedback loops and is not allowed.");
     }
 
-    std::cerr << "listening for remote topics of type " << msg_type << " on topic "
-              << full_from_topic << " and publishing as " << full_to_topic
-              << std::endl;
+    std::cerr << "listening for remote topics of type " << msg_type
+              << " on topic " << full_from_topic << " and publishing as "
+              << full_to_topic << std::endl;
 
     // create function that will decode and publish a T message to any topic
     if (pub_fns.count(msg_type) == 0) {
-      pub_fns[msg_type] =
-          [this, full_to_topic](const QByteArray& data, const std::string& msg_type) {
-            const T msg = decode<T>(data.data());
-            publish_ros_msg<T>(msg, msg_type, full_to_topic);
-          };
+      pub_fns[msg_type] = [this, full_to_topic](
+                              const QByteArray& data,
+                              const std::string& msg_type) {
+        const T msg = decode<T>(data.data());
+        publish_ros_msg<T>(msg, msg_type, full_to_topic);
+      };
     }
-    
+
     pub_remote_topics.push_back(full_from_topic);
   }
 

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -8,7 +8,6 @@
 #include <QObject>
 #include <thread>
 #include <unordered_map>
-#include <regex>
 
 #include "decode.hpp"
 #include "encode.hpp"
@@ -100,13 +99,10 @@ class RosClientNode : public QObject {
    */
   void subscribe_remote_msgs() {
     for(auto topic : pub_remote_topics) {
-      printf("ENCODING TOPIC %s\n", topic.c_str());
       // Now, subscribe to the appropriate remote message
       amrl_msgs::RobofleetSubscription sub_msg;
       sub_msg.action = amrl_msgs::RobofleetSubscription::ACTION_SUBSCRIBE;
-      std::string topic_regex = topic;
-      // std::regex_replace(topic_regex, std::regex("/"), "\\/");;
-      sub_msg.topic_regex = topic_regex;
+      sub_msg.topic_regex = topic;
       encode_ros_msg<amrl_msgs::RobofleetSubscription>(sub_msg, ros::message_traits::DataType<amrl_msgs::RobofleetSubscription>().value(), "/subscriptions");
     }
   }

--- a/src/WsClient.hpp
+++ b/src/WsClient.hpp
@@ -124,6 +124,13 @@ class WsClient : public QObject {
         &ros_node,
         &RosClientNode::decode_net_message);
 
+    // startup
+    QObject::connect(
+        this,
+        &WsClient::connected,
+        &ros_node,
+        &RosClientNode::subscribe_remote_msgs);
+
     // auto reconnect
     recon_timer.setSingleShot(true);
     QObject::connect(

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -69,7 +69,7 @@ static void configure_msg_types(RosClientNode& cn) {
   cn.register_local_msg_type<amrl_msgs::RobofleetSubscription>(
       "/subscriptions", webviz_constants::subscriptions_topic);
 
- // Set up listeners for local messages for webviz
+  // Set up listeners for local messages for webviz
   cn.register_local_msg_type<amrl_msgs::Localization2DMsg>(
       "/localization", webviz_constants::localization_topic);
 
@@ -90,11 +90,9 @@ static void configure_msg_types(RosClientNode& cn) {
 
   // Set up listeners for remote messages
   cn.register_remote_msg_type<amrl_msgs::Pose2Df>(
-      "move_base_simple/goal", "/move_base_simple/goal"
-  );
+      "move_base_simple/goal", "/move_base_simple/goal");
   cn.register_remote_msg_type<amrl_msgs::Localization2DMsg>(
-      "initialpose", "/initialpose"
-  );
+      "initialpose", "/initialpose");
 
   // Add additional topics to subscribe and publish here.
 }


### PR DESCRIPTION
Makes it so for topics that the user configured specifically to listen to will automatically get subscribed to. This mitigates the need for manually sending subscription messages from the robot client.