### PR TITLE
Add Dockerfile and Actions CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/.git
+**/build
+**/msg_gen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: test
+on: push
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - run: scripts/ci-test.sh 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ros:melodic-robot
+RUN apt-get update && apt-get install -y \
+  vim \
+  qt5-default \
+  libqt5websockets5-dev
+COPY . /robofleet_client

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Run the checks for continuous integration
+scripts/docker-build.sh
+docker run --rm -w /robofleet_client robofleet-client scripts/destructive/run-tests.sh

--- a/scripts/destructive/run-tests.sh
+++ b/scripts/destructive/run-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cp src/config.example.hpp src/config.hpp
+make test

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker build -t robofleet-client .
+

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
+# Build the Docker image robofleet-client
 docker build -t robofleet-client .
-

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker run --rm -w /robofleet_client -it robofleet_client
+

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-docker run --rm -w /robofleet_client -it robofleet_client
-
+# Run a command interactively in a Docker container (give no arguments to enter bash)
+docker run --rm -w /robofleet_client -it robofleet-client $@


### PR DESCRIPTION
- Now, GitHub Actions runs `make test` to verify that tests pass. (you can see this at the bottom of this PR)
  There aren't really any good tests in there yet, so it mostly just checks that the code builds.
- This is accomplished by creating a `Dockerfile`, which defines an environment in which robofleet_client can be built. 
  This does **not** mean that you _need_ Docker to build robofleet_client, but that you _can_ use a Docker container to build robofleet_client, without having to install dependencies.
  - You can easily run the CI checks yourself (with docker installed); just run `scripts/ci-test.sh`
- This has some potential future advantages: once the other components of Robofleet have Dockerfiles, we can use docker-compose to create integration tests (or a development environment) in the root Robofleet repository.

I've configured this repo to require passing tests to merge code into master. I don't plan to require approvals, since we have a small team. The new workflow is simply to create PRs, wait for tests to pass, and click the button to merge.