### PR TITLE
Attempt to fix client -> server backpressure for real

### DIFF
--- a/src/WsClient.hpp
+++ b/src/WsClient.hpp
@@ -19,7 +19,7 @@ class WsClient : public QObject {
 
   // used to track which messages the server has received
   uint64_t last_ponged_index = 0;
-  uint64_t msg_index = 1;
+  uint64_t msg_index = 0;
 
  public Q_SLOTS:
   void on_error(QAbstractSocket::SocketError error) {
@@ -78,10 +78,9 @@ class WsClient : public QObject {
         msg_index - last_ponged_index > config::max_queue_before_waiting)
       return;
 
-    ws.sendBinaryMessage(data);
-
-    send_ping();
     ++msg_index;
+    ws.sendBinaryMessage(data);
+    send_ping();
   }
 
  Q_SIGNALS:

--- a/src/WsClient.hpp
+++ b/src/WsClient.hpp
@@ -64,14 +64,16 @@ class WsClient : public QObject {
 
   void send_message(const QByteArray& data) {
     // don't buffer more data if we're waiting for old messages to be ACK'd
-    if (config::wait_for_pongs && msg_index - last_ponged_index > config::max_queue_before_waiting)
+    if (config::wait_for_pongs &&
+        msg_index - last_ponged_index > config::max_queue_before_waiting)
       return;
 
     ws.sendBinaryMessage(data);
 
-    // reinterprets msg_index as a byte array; 
+    // reinterprets msg_index as a byte array;
     // endianness is not important since this data is just echoed back as is.
-    const QByteArray msg_index_payload{reinterpret_cast<char*>(&msg_index), sizeof(msg_index)};
+    const QByteArray msg_index_payload{
+        reinterpret_cast<char*>(&msg_index), sizeof(msg_index)};
     ws.ping(msg_index_payload);
     ++msg_index;
   }
@@ -104,8 +106,7 @@ class WsClient : public QObject {
         &QWebSocket::binaryMessageReceived,
         this,
         &WsClient::on_binary_message);
-    QObject::connect(
-        &ws, &QWebSocket::pong, this, &WsClient::on_pong);
+    QObject::connect(&ws, &QWebSocket::pong, this, &WsClient::on_pong);
     reconnect();
   }
 

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -13,24 +13,38 @@
 #include "WebVizConstants.hpp"
 
 namespace config {
+static const std::string ros_node_name = "robofleet_client";
+
 // URL of robofleet_server instance (ignored in direct mode)
 static const std::string host_url = "ws://localhost:8080";
-// AMRL Robofleet server URL
-// static const std::string host_url = "ws://10.0.0.1:8080";
+// static const std::string host_url = "ws://10.0.0.1:8080"; // AMRL Robofleet server URL
 
-// whether to run a Websocket server instead of a client, to bypass the need
-// for a centralized instance of robofleet_server.
+/**
+ * Anti-backpressure for normal mode.
+ * Uses Websocket PING/PONG protocol to gauge when server has actually received a message.
+ * If true, wait for PONGs before sending more messages.
+ */
+static const bool wait_for_pongs = true;
+
+/**
+ * If wait_for_acks, how many more messages to send before waiting for first PONG?
+ * This can be set to a value greater than 0 to compensate for network latency and
+ * fully saturate available bandwidth, but if it is set too high, it could cause 
+ * message lag.
+ */
+static const uint64_t max_queue_before_waiting = 1;
+
+/**
+ * Whether to run a Websocket server instead of a client, to bypass the need
+ * for a centralized instance of robofleet_server.
+ */
 static const bool direct_mode = false;
+
 // what port to serve on in direct mode
 static const quint16 direct_mode_port = 8080;
 
-// rate limiting:
-// in normal mode, how many bytes to buffer for sending before dropping messages
-static const qint64 max_send_buffer_bytes = 128000;
-// in direct mode, maximum upload speed
+// avoid network backpressure in direct mode: sets maximum upload speed
 static const quint64 direct_mode_bytes_per_sec = 2048000;
-
-static const std::string ros_node_name = "robofleet_client";
 
 /**
  * Configure all message types with which the client will interact.

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -17,20 +17,21 @@ static const std::string ros_node_name = "robofleet_client";
 
 // URL of robofleet_server instance (ignored in direct mode)
 static const std::string host_url = "ws://localhost:8080";
-// static const std::string host_url = "ws://10.0.0.1:8080"; // AMRL Robofleet server URL
+// AMRL Robofleet server URL
+// static const std::string host_url = "ws://10.0.0.1:8080";
 
 /**
  * Anti-backpressure for normal mode.
- * Uses Websocket PING/PONG protocol to gauge when server has actually received a message.
- * If true, wait for PONGs before sending more messages.
+ * Uses Websocket PING/PONG protocol to gauge when server has actually received
+ * a message. If true, wait for PONGs before sending more messages.
  */
 static const bool wait_for_pongs = true;
 
 /**
- * If wait_for_acks, how many more messages to send before waiting for first PONG?
- * This can be set to a value greater than 0 to compensate for network latency and
- * fully saturate available bandwidth, but if it is set too high, it could cause 
- * message lag.
+ * If wait_for_acks, how many more messages to send before waiting for first
+ * PONG? This can be set to a value greater than 0 to compensate for network
+ * latency and fully saturate available bandwidth, but if it is set too high, it
+ * could cause message lag.
  */
 static const uint64_t max_queue_before_waiting = 1;
 
@@ -94,10 +95,13 @@ static void configure_msg_types(RosClientNode& cn) {
       "/velodyne_2dscan", webviz_constants::lidar_2d_topic, 15);
 
   cn.register_local_msg_type<sensor_msgs::CompressedImage>(
-      "/stereo/left/image_raw/compressed", webviz_constants::left_image_topic, 10);
+      "/stereo/left/image_raw/compressed",
+      webviz_constants::left_image_topic,
+      10);
   cn.register_local_msg_type<sensor_msgs::CompressedImage>(
       "/stereo/right/image_raw/compressed",
-      webviz_constants::right_image_topic, 10);
+      webviz_constants::right_image_topic,
+      10);
 
   cn.register_local_msg_type<amrl_msgs::VisualizationMsg>(
       "/visualization", webviz_constants::visualization_topic, 10);


### PR DESCRIPTION
This is an attempt to fix ut-amrl/robofleet#6, which is the issue that we are still seeing lag (a large time delay with messages queuing up) in webviz visualization when network bandwidth is limited.

This works using the Websocket ping/pong protocol, which allows for sending and echoing a payload. I assume that the Websocket server is handling all messages in a FIFO fashion, and I can therefore ping the server with a message ID and wait for it to pong back the same ID before sending more messages.

This fixes the issue reproduced using artificial bandwidth limiting that I described on the linked issue.