### PR TITLE
Add MessageScheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ The client must be configured before building.
 1. `cp src/config.example.hpp src/config.hpp`
 2. Edit parameters in `src/config.hpp`
 
+Below is more information about configuration options in `src/config.hpp`.
+
+### Topic configuration
+You must tell the client exactly which ROS topics to exchange with the Robofleet server. To set which topics the client sends and receives, you can follow the examples in the `configure_msg_types()` function.
+
+Keep in mind that all ROS topic [names][names] are [resolved][name resolution], meaning most importantly that topics not beginning with a `/` are prefixed with the ROS namespace.
+
+There are two available configuration builders:
+
+`SendLocalTopic<T>` - subscribe to messages on a local ROS topic and send them to the server. `T` is a ROS message class.
+* `.from` - the name of the local ROS topic
+* `.to` - the name of the remote ROS topic (can be the same; allows for remapping)
+* `.priority` - larger priority means the topic will receive more bandwidth. Priority is an arbitrary positive value where the ratio of priorities between topics determines how much bandwidth each is allocated.
+* `.no_drop` - `true` means to never drop messages on this topic and queue them instead. **Can cause lag** and should only be used for messages that are sent infrequently. Messages on topics flagged as `no_drop` are scheduled in FIFO order and always take priority over other messages.
+* `.rate_limit_hz` - set the maximum rate of message sending to a given value in hz (default unlimited). This is only required if you want to impose a hard limit on message frequency; you can always use `priority` to adjust how much bandwidth is allocated to each topic.
+
+`ReceiveRemoteTopic<T>` - receive messages from the server and publish them to a local ROS topic. `T` is a ROS message class.
+* `.from` - the name of the remote ROS topic
+* `.to` - the name of the local ROS topic
+
 ### Direct mode
 
 By default, the Robofleet robot client runs a WebSocket client, which connects to an instance of `robofleet_server`. You can then use `robofleet_webviz` to connect to the server and interact with connected robots. In some cases, you may not need the features provided by `robofleet_server`, or you may not want to run the Node.js application. In this case, you can enable "direct mode" in the robot client, which causes it to accept connections as a WebSocket server instead of acting as a WebSocket client. You can then use `robofleet_webviz` to connect directly to the robot running the robot client, instead of connecting to an intermediary instance of `robofleet_server`.
@@ -32,7 +52,7 @@ To switch to direct mode, set the `direct_mode` flag in `src/config.hpp` and mak
 
 ### Using namespaces
 
-1. Read the ROS wiki on [names](http://wiki.ros.org/Names) and [name remapping](http://wiki.ros.org/Remapping%20Arguments).
+1. Read the ROS wiki on [names][names] and [name resolution][name resolution].
 2. Launch with `ROS_NAMESPACE` set, e.g. `ROS_NAMESPACE="ut/testbot" make run` or by using `export` to set the environment variable beforehand.
 
 Note that if you run two client nodes on one machine (even in different namespaces), it is possible to create a feedback loop by client B receiving client A's messages from the server, and then re-publishing them to client A's topic.
@@ -43,3 +63,6 @@ Note that if you run two client nodes on one machine (even in different namespac
   * Build once to generate amrl_msgs
   * Add `amrl_msgs/msg_gen/cpp/include` to your include paths
   * VS Code editor settings are included
+
+[names]: https://wiki.ros.org/Names#Resolving
+[name resolution]: https://wiki.ros.org/Names#Resolving

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,4 +7,5 @@ PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/WsServer.hpp
     ${CMAKE_CURRENT_LIST_DIR}/WebVizConstants.hpp
     ${CMAKE_CURRENT_LIST_DIR}/RosClientNode.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/MessageScheduler.hpp
 )

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -1,0 +1,94 @@
+#pragma once
+#include <QObject>
+#include <QString>
+#include <QByteArray>
+#include <QDebug>
+#include <cstdint>
+#include <unordered_map>
+#include <deque>
+#include <string>
+#include <chrono>
+
+
+/**
+ * @brief Queues messages and schedules them on demand.
+ * 
+ * Messages are enqueued, and then later scheduled (via the scheduled signal)
+ * when schedule() is called. The scheduling algorithm is approximately a token
+ * bucket filter.
+ */
+class MessageScheduler : public QObject {
+  Q_OBJECT
+  using Clock = std::chrono::high_resolution_clock;
+  using TimePoint = Clock::time_point;
+
+  const double target_saturation = 0.7;
+  double approx_bytes_per_sec = 0; // rate at which to generate bandwidth
+  const double min_bytes_per_sec = 64; // assume at least this much bandwidth
+  double bandwidth_bucket = 0; // currently accumulated bandwidth
+  const double bucket_max_size_sec = 0.5; // how many sec worth of bandwidth can the bucket store? 
+  TimePoint last_timestamp = Clock::now(); // when bandwidth was last generated
+
+  std::deque<std::tuple<QString, QByteArray>> queue;
+
+  void update_bucket() {
+    const TimePoint now = Clock::now();
+    const double elapsed_sec = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_timestamp).count() / 1000.0;
+    const double bytes_per_sec = std::max(min_bytes_per_sec, approx_bytes_per_sec);
+    const double bucket_max_size = bucket_max_size_sec * bytes_per_sec;
+
+    bandwidth_bucket += elapsed_sec * bytes_per_sec * target_saturation;
+    bandwidth_bucket = std::min(bandwidth_bucket, bucket_max_size);
+    qDebug() << "BUCKET kB: " << (bandwidth_bucket / 1000.0);
+    last_timestamp = now;
+  }
+
+  bool consume_bandwidth(int bytes) {
+    if (bandwidth_bucket <= 0) {
+      return false;
+    }
+    bandwidth_bucket -= bytes;
+    return true;
+  }
+
+public:
+  MessageScheduler() {}
+
+  Q_SIGNALS:
+  void scheduled(const QString& topic, const QByteArray& data);
+
+public Q_SLOTS:
+  /**
+   * @brief Set the estimated bandwidth
+   * @param bytes_per_sec estimated network bandwidth
+   */
+  void set_bandwidth(double bytes_per_sec) {
+    approx_bytes_per_sec = bytes_per_sec;
+  }
+
+  void enqueue(const QString& topic, const QByteArray& data) {
+    if (queue.size() > 2) {
+      queue.pop_front();
+    }
+    queue.push_back(std::make_tuple(topic, data));
+    schedule();
+  }
+
+  /**
+   * @brief Schedule messages now.
+   */
+  void schedule() {
+    update_bucket();
+    while (!queue.empty()) {
+      const auto next = queue.front();
+      const auto next_size_bytes = std::get<1>(next).size();
+      if (consume_bandwidth(next_size_bytes)) {
+        queue.pop_front();
+        Q_EMIT scheduled(std::get<0>(next), std::get<1>(next));
+        qDebug() << "\x1b[31mscheduled\x1b[0m";
+      } else {
+        break;
+      }
+    }
+  }
+};

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -30,6 +30,13 @@ struct WaitingMessage {
       std::chrono::duration<double>::zero();
 };
 
+// for compatibility
+struct QStringHash {
+  std::size_t operator()(const QString& s) const {
+    return qHash(s);
+  }
+};
+
 /**
  * @brief Queues messages and schedules them on demand.
  *
@@ -41,7 +48,7 @@ class MessageScheduler : public QObject {
   bool is_network_unblocked = true;
 
   std::deque<QByteArray> no_drop_queue;
-  std::unordered_map<QString, WaitingMessage> topic_queue;
+  std::unordered_map<QString, WaitingMessage, QStringHash> topic_queue;
 
  public:
   MessageScheduler() {

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -1,14 +1,10 @@
 #pragma once
 #include <QByteArray>
-#include <QDebug>
 #include <QHash>
 #include <QObject>
 #include <QString>
 #include <chrono>
-#include <cstdint>
 #include <deque>
-#include <map>
-#include <string>
 #include <unordered_map>
 
 using SchedulerClock = std::chrono::high_resolution_clock;
@@ -119,7 +115,6 @@ class MessageScheduler : public QObject {
       if (candidate.time_waiting > next->second.time_waiting) {
         next = it;
       }
-      qDebug() << candidate_topic << candidate.time_waiting.count();
     }
 
     if (next->second.message_ready) {

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -52,13 +52,6 @@ public:
   void scheduled(const QByteArray& data);
 
 public Q_SLOTS:
-  /**
-   * @brief Set the estimated bandwidth
-   * @param bytes_per_sec estimated network bandwidth
-   */
-  void set_bandwidth(double bytes_per_sec) {
-  }
-
   void enqueue(const QString& topic, const QByteArray& data, int priority, bool no_drop) {
     if (no_drop) {
       no_drop_queue.push_back(data);

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <QByteArray>
 #include <QDebug>
+#include <QHash>
 #include <QObject>
 #include <QString>
 #include <chrono>
@@ -34,7 +35,7 @@ namespace std {
 template <>
 struct hash<PrioritizedTopic> {
   std::size_t operator()(const PrioritizedTopic& t) const noexcept {
-    return std::hash<QString>()(t.topic) ^ std::hash<double>()(t.priority);
+    return qHash(t.topic) ^ std::hash<double>()(t.priority);
   }
 };
 };  // namespace std

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -86,6 +86,7 @@ public Q_SLOTS:
         const auto& next = no_drop_queue.front();
         Q_EMIT scheduled(next);
         no_drop_queue.pop_front();
+        qDebug() << "\x1b[33mnodrop\x1b[0m";
       }
       return;
     }

--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -76,7 +76,6 @@ public Q_SLOTS:
    */
   void network_unblocked() {
     is_network_unblocked = true;
-    qDebug() << "\x1b[35mUNBLOCKED\x1b[0m";
     schedule();
   }
 
@@ -95,7 +94,6 @@ public Q_SLOTS:
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_schedule_time).count();
     const double elapsed_s = elapsed / 1000.0;
     last_schedule_time = now;
-    qDebug() << elapsed_s << "elapsed";
 
     // flush no-drop queue
     if (!no_drop_queue.empty()) {
@@ -103,7 +101,6 @@ public Q_SLOTS:
         const auto& next = no_drop_queue.front();
         Q_EMIT scheduled(next);
         no_drop_queue.pop_front();
-        qDebug() << "\x1b[33mnodrop\x1b[0m";
       }
       is_network_unblocked = false;
       return;
@@ -121,7 +118,6 @@ public Q_SLOTS:
       WaitingMessage& candidate_val = it->second;
       candidate_val.total_prioritized_wait += candidate_key.priority * elapsed_s;
 
-      qDebug() << candidate_key.topic << "\x1b[32mwait was\x1b[0m" << candidate_val.total_prioritized_wait;
       if (candidate_val.total_prioritized_wait > next->second.total_prioritized_wait) {
         next = it;
       }
@@ -129,12 +125,9 @@ public Q_SLOTS:
 
     if (next->second.is_waiting) {
       Q_EMIT scheduled(next->second.message);
-      qDebug() << "\x1b[35mscheduled\x1b[0m" << next->first.topic;
       next->second.is_waiting = false;
       next->second.total_prioritized_wait = 0;
       is_network_unblocked = false;
-    } else {
-      qDebug() << "\x1b[31mwaiting\x1b[0m" << next->first.topic;
     }
   }
 };

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -19,7 +19,7 @@ class RosClientNode : public QObject {
   Q_OBJECT
 
   struct TopicParams {
-    int priority;
+    double priority;
     bool no_drop;
   };
 
@@ -126,7 +126,7 @@ class RosClientNode : public QObject {
   }
 
  Q_SIGNALS:
-  void ros_message_encoded(const QString& topic, const QByteArray& data, int priority, bool no_drop);
+  void ros_message_encoded(const QString& topic, const QByteArray& data, double priority, bool no_drop);
 
  public Q_SLOTS:
   /**

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -13,6 +13,7 @@
 #include "decode.hpp"
 #include "encode.hpp"
 #include "TopicConfig.hpp"
+#include "MessageScheduler.hpp"
 
 class RosClientNode : public QObject {
   Q_OBJECT
@@ -54,7 +55,7 @@ class RosClientNode : public QObject {
       auto metadata = encode_metadata(fbb, msg_type, to_topic);
       auto root_offset = encode<T>(fbb, msg, metadata);
       fbb.Finish(flatbuffers::Offset<void>(root_offset));
-      Q_EMIT ros_message_encoded(QByteArray(
+      Q_EMIT ros_message_encoded(QString::fromStdString(to_topic), QByteArray(
           reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize()));
     }
   }
@@ -66,7 +67,7 @@ class RosClientNode : public QObject {
   }
 
  Q_SIGNALS:
-  void ros_message_encoded(const QByteArray& data);
+  void ros_message_encoded(const QString& topic, const QByteArray& data);
 
  public Q_SLOTS:
   /**

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -56,7 +56,7 @@ class RosClientNode : public QObject {
       auto root_offset = encode<T>(fbb, msg, metadata);
       fbb.Finish(flatbuffers::Offset<void>(root_offset));
       const QByteArray data{reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize()};
-      Q_EMIT ros_message_encoded(QString::fromStdString(to_topic), data, 0, true);
+      Q_EMIT ros_message_encoded(QString::fromStdString(to_topic), data, 1, false);
     }
   }
 

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -12,7 +12,7 @@
 
 #include "decode.hpp"
 #include "encode.hpp"
-#include "TopicConfig.hpp"
+#include "topic_config.hpp"
 #include "MessageScheduler.hpp"
 
 class RosClientNode : public QObject {
@@ -254,7 +254,7 @@ class RosClientNode : public QObject {
   void configure(const Config& config);
   
   template <typename T>
-  void configure(const SendLocalTopic<T>& config) {
+  void configure(const topic_config::SendLocalTopic<T>& config) {
     config.assert_valid();
     register_local_msg_type<T>(config.from, config.to);
     if (config.rate_limit_hz.is_set()) {
@@ -265,7 +265,7 @@ class RosClientNode : public QObject {
   }
 
   template <typename T>
-  void configure(const ReceiveRemoteTopic<T>& config) {
+  void configure(const topic_config::ReceiveRemoteTopic<T>& config) {
     config.assert_valid();
     register_remote_msg_type<T>(config.from, config.to);
   }

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -55,8 +55,8 @@ class RosClientNode : public QObject {
       auto metadata = encode_metadata(fbb, msg_type, to_topic);
       auto root_offset = encode<T>(fbb, msg, metadata);
       fbb.Finish(flatbuffers::Offset<void>(root_offset));
-      Q_EMIT ros_message_encoded(QString::fromStdString(to_topic), QByteArray(
-          reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize()));
+      const QByteArray data{reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize()};
+      Q_EMIT ros_message_encoded(QString::fromStdString(to_topic), data, 0, true);
     }
   }
 
@@ -67,7 +67,7 @@ class RosClientNode : public QObject {
   }
 
  Q_SIGNALS:
-  void ros_message_encoded(const QString& topic, const QByteArray& data);
+  void ros_message_encoded(const QString& topic, const QByteArray& data, int priority, bool no_drop);
 
  public Q_SLOTS:
   /**

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -69,7 +69,7 @@ class RosClientNode : public QObject {
     auto metadata = encode_metadata(fbb, msg_type, to_topic);
     auto root_offset = encode<T>(fbb, msg, metadata);
     fbb.Finish(flatbuffers::Offset<void>(root_offset));
-    const QByteArray data{reinterpret_cast<const char*>(fbb.GetBufferPointer()), fbb.GetSize()};
+    const QByteArray data{reinterpret_cast<const char*>(fbb.GetBufferPointer()), static_cast<int>(fbb.GetSize())};
     const TopicParams& params = topic_params[to_topic];
     Q_EMIT ros_message_encoded(QString::fromStdString(to_topic), data, params.priority, params.no_drop);
   }

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -12,6 +12,7 @@
 
 #include "decode.hpp"
 #include "encode.hpp"
+#include "TopicConfig.hpp"
 
 class RosClientNode : public QObject {
   Q_OBJECT
@@ -205,6 +206,26 @@ class RosClientNode : public QObject {
     }
 
     pub_remote_topics.push_back(full_from_topic);
+  }
+
+  /**
+   * @brief Register new listeners based on the given topic configuration.
+   * 
+   * Depending on the source set in config, this will either listen to messages
+   * on a local topic, or listen to messages on a remote topic. If a remote 
+   * topic is specified, we will subscribe to it by default.
+   * 
+   * @tparam T the ROS message type
+   * @param config
+   */
+  template <typename T>
+  void configure(const TopicConfig<T>& config) {
+    config.assert_valid();
+    if (config.source == MessageSource::local) {
+      register_local_msg_type<T>(config.from, config.to, config.rate_limit_hz);
+    } else {
+      register_remote_msg_type<T>(config.from, config.to);
+    }
   }
 
   RosClientNode() {

--- a/src/TopicConfig.hpp
+++ b/src/TopicConfig.hpp
@@ -64,7 +64,7 @@ struct SendLocalTopic {
   BuilderProp<SendLocalTopic, std::string> from{*this};
   BuilderProp<SendLocalTopic, std::string> to{*this};
   BuilderProp<SendLocalTopic, double> rate_limit_hz{*this};
-  BuilderProp<SendLocalTopic, int> priority{*this, 1};
+  BuilderProp<SendLocalTopic, double> priority{*this, 1};
   BuilderProp<SendLocalTopic, bool> no_drop{*this, false};
 
   void assert_valid() const {

--- a/src/TopicConfig.hpp
+++ b/src/TopicConfig.hpp
@@ -1,0 +1,73 @@
+#pragma once
+#include <exception>
+#include <string>
+
+template <typename Builder, typename T>
+class BuilderProp {
+  bool _set = false;
+  Builder& _builder;
+  T _thing;
+
+ public:
+  BuilderProp(Builder& builder) : _builder(builder) {
+  }
+  BuilderProp(Builder& builder, const T& thing) : _builder(builder) {
+    set(thing);
+  }
+
+  Builder& operator()(const T& thing) {
+    set(thing);
+    return _builder;
+  }
+
+  operator T() const {
+    return T(get());
+  }
+
+  void operator=(const T& thing) {
+    set(thing);
+  }
+
+  void unset() {
+    _set = false;
+  }
+
+  bool is_set() const {
+    return _set;
+  }
+
+  void assert_set() const {
+    if (!is_set()) {
+      throw std::runtime_error("Value not set!");
+    }
+  }
+
+  void set(const T& thing) {
+    _thing = thing;
+    _set = true;
+  }
+
+  const T& get() const {
+    assert_set();
+    return _thing;
+  }
+};
+
+enum class MessageSource { local, remote };
+
+template <typename RosType>
+struct TopicConfig {
+  BuilderProp<TopicConfig, MessageSource> source{*this};
+  BuilderProp<TopicConfig, std::string> from{*this};
+  BuilderProp<TopicConfig, std::string> to{*this};
+  BuilderProp<TopicConfig, double> rate_limit_hz{*this, 0};
+  BuilderProp<TopicConfig, int> priority{*this, 0};
+
+  void assert_valid() const {
+    source.assert_set();
+    from.assert_set();
+    to.assert_set();
+    rate_limit_hz.assert_set();
+    priority.assert_set();
+  }
+};

--- a/src/TopicConfig.hpp
+++ b/src/TopicConfig.hpp
@@ -57,6 +57,9 @@ enum class MessageSource { local, remote };
 
 template <typename RosType>
 struct TopicConfig {
+  /**
+   * @brief Whether the message is received from the local ROS master or the network.
+   */
   BuilderProp<TopicConfig, MessageSource> source{*this};
   BuilderProp<TopicConfig, std::string> from{*this};
   BuilderProp<TopicConfig, std::string> to{*this};

--- a/src/TopicConfig.hpp
+++ b/src/TopicConfig.hpp
@@ -53,22 +53,21 @@ class BuilderProp {
   }
 };
 
-enum class MessageSource { local, remote };
-
+/**
+ * @brief Config for sending messages from a local topic to Robofleet
+ * 
+ * This creates a ROS subscriber to bridge local messages to Robofleet.
+ * @tparam RosType the ROS message class being sent on the topic
+ */
 template <typename RosType>
-struct TopicConfig {
-  /**
-   * @brief Whether the message is received from the local ROS master or the network.
-   */
-  BuilderProp<TopicConfig, MessageSource> source{*this};
-  BuilderProp<TopicConfig, std::string> from{*this};
-  BuilderProp<TopicConfig, std::string> to{*this};
-  BuilderProp<TopicConfig, double> rate_limit_hz{*this};
-  BuilderProp<TopicConfig, int> priority{*this, 1};
-  BuilderProp<TopicConfig, bool> no_drop{*this, false};
+struct SendLocalTopic {
+  BuilderProp<SendLocalTopic, std::string> from{*this};
+  BuilderProp<SendLocalTopic, std::string> to{*this};
+  BuilderProp<SendLocalTopic, double> rate_limit_hz{*this};
+  BuilderProp<SendLocalTopic, int> priority{*this, 1};
+  BuilderProp<SendLocalTopic, bool> no_drop{*this, false};
 
   void assert_valid() const {
-    source.assert_set();
     from.assert_set();
     to.assert_set();
     priority.assert_set();
@@ -76,5 +75,22 @@ struct TopicConfig {
       throw std::runtime_error("Priority must be greater than 0!");
     }
     no_drop.assert_set();
+  }
+};
+
+/**
+ * @brief Config for receiving messages from a remote topic on Robofleet
+ * 
+ * This creates a ROS publisher to bridge remote messages to the robot.
+ * @tparam RosType the ROS message class being sent on the topic
+ */
+template <typename RosType>
+struct ReceiveRemoteTopic {
+  BuilderProp<ReceiveRemoteTopic, std::string> from{*this};
+  BuilderProp<ReceiveRemoteTopic, std::string> to{*this};
+
+  void assert_valid() const {
+    from.assert_set();
+    to.assert_set();
   }
 };

--- a/src/TopicConfig.hpp
+++ b/src/TopicConfig.hpp
@@ -63,14 +63,18 @@ struct TopicConfig {
   BuilderProp<TopicConfig, MessageSource> source{*this};
   BuilderProp<TopicConfig, std::string> from{*this};
   BuilderProp<TopicConfig, std::string> to{*this};
-  BuilderProp<TopicConfig, double> rate_limit_hz{*this, 0};
-  BuilderProp<TopicConfig, int> priority{*this, 0};
+  BuilderProp<TopicConfig, double> rate_limit_hz{*this};
+  BuilderProp<TopicConfig, int> priority{*this, 1};
+  BuilderProp<TopicConfig, bool> no_drop{*this, false};
 
   void assert_valid() const {
     source.assert_set();
     from.assert_set();
     to.assert_set();
-    rate_limit_hz.assert_set();
     priority.assert_set();
+    if (priority <= 0) {
+      throw std::runtime_error("Priority must be greater than 0!");
+    }
+    no_drop.assert_set();
   }
 };

--- a/src/WsClient.hpp
+++ b/src/WsClient.hpp
@@ -62,7 +62,7 @@ class WsClient : public QObject {
     uint64_t ponged_index = *reinterpret_cast<const uint64_t*>(payload.data());
     last_ponged_index = std::max(last_ponged_index, ponged_index);
 
-    if (msg_index - last_ponged_index < config::max_queue_before_waiting) {
+    if (msg_index - last_ponged_index <= config::max_queue_before_waiting) {
       Q_EMIT network_unblocked();
     }
   }

--- a/src/WsClient.hpp
+++ b/src/WsClient.hpp
@@ -3,10 +3,10 @@
 #include <QObject>
 #include <QTimer>
 #include <QtWebSockets/QtWebSockets>
+#include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <unordered_map>
-#include <chrono>
 
 #include "config.hpp"
 

--- a/src/WsClient.hpp
+++ b/src/WsClient.hpp
@@ -3,19 +3,13 @@
 #include <QObject>
 #include <QTimer>
 #include <QtWebSockets/QtWebSockets>
-#include <chrono>
 #include <cstdint>
 #include <iostream>
-#include <unordered_map>
 
 #include "config.hpp"
 
-const static int ws_msg_overhead_bytes = 14;
-
 class WsClient : public QObject {
   Q_OBJECT;
-  using Clock = std::chrono::high_resolution_clock;
-  using TimePoint = Clock::time_point;
 
   QUrl url;
   QWebSocket ws;
@@ -58,7 +52,7 @@ class WsClient : public QObject {
     Q_EMIT message_received(data);
   }
 
-  void on_pong(qint64 _elapsed_time, const QByteArray& payload) {
+  void on_pong(qint64 elapsed_time, const QByteArray& payload) {
     uint64_t ponged_index = *reinterpret_cast<const uint64_t*>(payload.data());
     last_ponged_index = std::max(last_ponged_index, ponged_index);
 
@@ -91,7 +85,6 @@ class WsClient : public QObject {
   void connected();
   void disconnected();
   void message_received(const QByteArray& data);
-  void bandwidth_estimated(double approx_bytes_per_sec);
   void network_unblocked();
 
  public:

--- a/src/WsServer.hpp
+++ b/src/WsServer.hpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <unordered_set>
 
-#include "RosClientNode.hpp"
 #include "config.hpp"
 
 class WsServer : public QObject {
@@ -118,25 +117,5 @@ class WsServer : public QObject {
   ~WsServer() {
     server->close();
     qDeleteAll(clients.begin(), clients.end());
-  }
-
-  void connect_ros_node(const RosClientNode& ros_node) {
-    // send
-    // Need to use string-based connect to support default arg.
-    // https://doc.qt.io/qt-5/signalsandslots-syntaxes.html
-    // Trivial lambda-based version will not work because it is called from
-    // another thread.
-    QObject::connect(
-        &ros_node,
-        SIGNAL(ros_message_encoded(const QByteArray&)),
-        this,
-        SLOT(broadcast_message(const QByteArray&)));
-
-    // receive
-    QObject::connect(
-        this,
-        &WsServer::binary_message_received,
-        &ros_node,
-        &RosClientNode::decode_net_message);
   }
 };

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -36,7 +36,7 @@ static const bool wait_for_pongs = true;
  * latency and fully saturate available bandwidth, but if it is set too high, it
  * could cause message lag.
  */
-static const uint64_t max_queue_before_waiting = 1;
+static const uint64_t max_queue_before_waiting = 0;
 
 /**
  * Whether to run a Websocket server instead of a client, to bypass the need
@@ -92,19 +92,19 @@ static void configure_msg_types(RosClientNode& cn) {
                    .from("/localization")
                    .to(webviz_constants::localization_topic)
                    .rate_limit_hz(10)
-                   .priority(100));
+                   .priority(20));
 
   cn.configure(SendLocalTopic<nav_msgs::Odometry>()
                    .from("/odometry/raw")
                    .to(webviz_constants::odometry_topic)
                    .rate_limit_hz(15)
-                   .priority(100));
+                   .priority(20));
 
   cn.configure(SendLocalTopic<sensor_msgs::LaserScan>()
                    .from("/velodyne_2dscan")
                    .to(webviz_constants::lidar_2d_topic)
                    .rate_limit_hz(15)
-                   .priority(5));
+                   .priority(2));
 
   cn.configure(SendLocalTopic<sensor_msgs::CompressedImage>()
                    .from("/stereo/left/image_raw/compressed")
@@ -121,7 +121,7 @@ static void configure_msg_types(RosClientNode& cn) {
                    .from("/visualization")
                    .to(webviz_constants::visualization_topic)
                    .rate_limit_hz(10)
-                   .priority(3));
+                   .priority(2));
 
   // receive remote commands
   cn.configure(ReceiveRemoteTopic<geometry_msgs::PoseStamped>()

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -74,48 +74,54 @@ static void configure_msg_types(RosClientNode& cn) {
     .rate_limit_hz(1));
 
   // must send to subscriptions topic to receive messages from other robots
-  // don't rate limit this topic.
+  // don't drop or rate limit this topic.
   cn.configure(TopicConfig<amrl_msgs::RobofleetSubscription>()
     .source(MessageSource::local)
     .from("/subscriptions")
     .to(webviz_constants::subscriptions_topic)
-    .rate_limit_hz(1));
+    .no_drop(true));
 
   // send messages for webviz
   cn.configure(TopicConfig<amrl_msgs::Localization2DMsg>()
     .source(MessageSource::local)
     .from("/localization")
     .to(webviz_constants::localization_topic)
-    .rate_limit_hz(10));
+    .rate_limit_hz(10)
+    .priority(10));
 
   cn.configure(TopicConfig<nav_msgs::Odometry>()
     .source(MessageSource::local)
     .from("/odometry/raw")
     .to(webviz_constants::odometry_topic)
-    .rate_limit_hz(15));
+    .rate_limit_hz(15)
+    .priority(10));
 
   cn.configure(TopicConfig<sensor_msgs::LaserScan>()
     .source(MessageSource::local)
     .from("/velodyne_2dscan")
     .to(webviz_constants::lidar_2d_topic)
-    .rate_limit_hz(15));
+    .rate_limit_hz(15)
+    .priority(5));
 
   cn.configure(TopicConfig<sensor_msgs::CompressedImage>()
     .source(MessageSource::local)
     .from("/stereo/left/image_raw/compressed")
     .to(webviz_constants::left_image_topic)
-    .rate_limit_hz(10));
+    .rate_limit_hz(10)
+    .priority(1));
   cn.configure(TopicConfig<sensor_msgs::CompressedImage>()
     .source(MessageSource::local)
     .from("/stereo/right/image_raw/compressed")
     .to(webviz_constants::right_image_topic)
-    .rate_limit_hz(10));
+    .rate_limit_hz(10)
+    .priority(1));
 
   cn.configure(TopicConfig<amrl_msgs::VisualizationMsg>()
     .source(MessageSource::local)
     .from("/visualization")
     .to(webviz_constants::visualization_topic)
-    .rate_limit_hz(10));
+    .rate_limit_hz(10)
+    .priority(3));
 
   // receive remote commands
   cn.configure(TopicConfig<geometry_msgs::PoseStamped>()

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -87,13 +87,13 @@ static void configure_msg_types(RosClientNode& cn) {
     .from("/localization")
     .to(webviz_constants::localization_topic)
     .rate_limit_hz(10)
-    .priority(10));
+    .priority(100));
 
   cn.configure(SendLocalTopic<nav_msgs::Odometry>()
     .from("/odometry/raw")
     .to(webviz_constants::odometry_topic)
     .rate_limit_hz(15)
-    .priority(10));
+    .priority(100));
 
   cn.configure(SendLocalTopic<sensor_msgs::LaserScan>()
     .from("/velodyne_2dscan")

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -10,8 +10,8 @@
 #include <string>
 
 #include "RosClientNode.hpp"
-#include "topic_config.hpp"
 #include "WebVizConstants.hpp"
+#include "topic_config.hpp"
 
 using namespace topic_config;
 
@@ -43,22 +43,25 @@ static const uint64_t max_queue_before_waiting = 1;
  * for a centralized instance of robofleet_server.
  */
 static const bool direct_mode = false;
-static const quint16 direct_mode_port = 8080; // what port to serve on in direct mode
-static const quint64 direct_mode_bytes_per_sec = 2048000; // avoid network backpressure in direct mode: sets maximum upload speed
+static const quint16 direct_mode_port =
+    8080;  // what port to serve on in direct mode
+static const quint64 direct_mode_bytes_per_sec =
+    2048000;  // avoid network backpressure in direct mode: sets maximum upload
+              // speed
 
 /**
  * @brief Configure which topics and types of messages the client will handle.
- * 
- * You should use the .configure() method on the RosClientNode, and supply 
+ *
+ * You should use the .configure() method on the RosClientNode, and supply
  * either a SendLocalTopic or a ReceiveRemoteTopic config.
- * 
- * To properly integrate with Robofleet, you need to run this client with a 
+ *
+ * To properly integrate with Robofleet, you need to run this client with a
  * ROS namespace representing the robot's name.
- * 
+ *
  * Absolute topic names begin with a "/"; they will not be prefixed with the
  * current ROS namespace (robot name). Many of your local ROS nodes may publish
  * on absolute-named topics.
- * Most topics must be relative (not begin with "/") on the server side to 
+ * Most topics must be relative (not begin with "/") on the server side to
  * avoid name collisions between robots.
  *
  * Tips:
@@ -73,61 +76,61 @@ static void configure_msg_types(RosClientNode& cn) {
 
   // must send to status topic to list robot in webviz
   cn.configure(SendLocalTopic<amrl_msgs::RobofleetStatus>()
-    .from("/status")
-    .to(webviz_constants::status_topic)
-    .rate_limit_hz(1));
+                   .from("/status")
+                   .to(webviz_constants::status_topic)
+                   .rate_limit_hz(1));
 
   // must send to subscriptions topic to receive messages from other robots
   // don't drop or rate limit this topic.
   cn.configure(SendLocalTopic<amrl_msgs::RobofleetSubscription>()
-    .from("/subscriptions")
-    .to(webviz_constants::subscriptions_topic)
-    .no_drop(true));
+                   .from("/subscriptions")
+                   .to(webviz_constants::subscriptions_topic)
+                   .no_drop(true));
 
   // send messages for webviz
   cn.configure(SendLocalTopic<amrl_msgs::Localization2DMsg>()
-    .from("/localization")
-    .to(webviz_constants::localization_topic)
-    .rate_limit_hz(10)
-    .priority(100));
+                   .from("/localization")
+                   .to(webviz_constants::localization_topic)
+                   .rate_limit_hz(10)
+                   .priority(100));
 
   cn.configure(SendLocalTopic<nav_msgs::Odometry>()
-    .from("/odometry/raw")
-    .to(webviz_constants::odometry_topic)
-    .rate_limit_hz(15)
-    .priority(100));
+                   .from("/odometry/raw")
+                   .to(webviz_constants::odometry_topic)
+                   .rate_limit_hz(15)
+                   .priority(100));
 
   cn.configure(SendLocalTopic<sensor_msgs::LaserScan>()
-    .from("/velodyne_2dscan")
-    .to(webviz_constants::lidar_2d_topic)
-    .rate_limit_hz(15)
-    .priority(5));
+                   .from("/velodyne_2dscan")
+                   .to(webviz_constants::lidar_2d_topic)
+                   .rate_limit_hz(15)
+                   .priority(5));
 
   cn.configure(SendLocalTopic<sensor_msgs::CompressedImage>()
-    .from("/stereo/left/image_raw/compressed")
-    .to(webviz_constants::left_image_topic)
-    .rate_limit_hz(10)
-    .priority(1));
+                   .from("/stereo/left/image_raw/compressed")
+                   .to(webviz_constants::left_image_topic)
+                   .rate_limit_hz(10)
+                   .priority(1));
   cn.configure(SendLocalTopic<sensor_msgs::CompressedImage>()
-    .from("/stereo/right/image_raw/compressed")
-    .to(webviz_constants::right_image_topic)
-    .rate_limit_hz(10)
-    .priority(1));
+                   .from("/stereo/right/image_raw/compressed")
+                   .to(webviz_constants::right_image_topic)
+                   .rate_limit_hz(10)
+                   .priority(1));
 
   cn.configure(SendLocalTopic<amrl_msgs::VisualizationMsg>()
-    .from("/visualization")
-    .to(webviz_constants::visualization_topic)
-    .rate_limit_hz(10)
-    .priority(3));
+                   .from("/visualization")
+                   .to(webviz_constants::visualization_topic)
+                   .rate_limit_hz(10)
+                   .priority(3));
 
   // receive remote commands
   cn.configure(ReceiveRemoteTopic<geometry_msgs::PoseStamped>()
-    .from("move_base_simple/goal")
-    .to("/move_base_simple/goal"));
+                   .from("move_base_simple/goal")
+                   .to("/move_base_simple/goal"));
 
   cn.configure(ReceiveRemoteTopic<amrl_msgs::Localization2DMsg>()
-    .from("initialpose")
-    .to("/initialpose"));
+                   .from("initialpose")
+                   .to("/initialpose"));
 
   // Add additional topics to subscribe and publish here.
 }

--- a/src/config.example.hpp
+++ b/src/config.example.hpp
@@ -10,8 +10,10 @@
 #include <string>
 
 #include "RosClientNode.hpp"
-#include "TopicConfig.hpp"
+#include "topic_config.hpp"
 #include "WebVizConstants.hpp"
+
+using namespace topic_config;
 
 namespace config {
 static const std::string ros_node_name = "robofleet_client";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageSchedul
     &ws_client,
     &WsClient::network_unblocked,
     &scheduler,
-    &MessageScheduler::schedule
+    &MessageScheduler::network_unblocked
   );
   // send scheduled message
   QObject::connect(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <ros/ros.h>
 
 #include <QtCore/QCoreApplication>
+#include <QObject>
 #include <chrono>
 #include <cstdint>
 #include <iostream>
@@ -9,7 +10,11 @@
 #include "RosClientNode.hpp"
 #include "WsClient.hpp"
 #include "WsServer.hpp"
+#include "MessageScheduler.hpp"
 #include "config.hpp"
+
+void connect_server(WsServer& ws_server, RosClientNode& ros_node, MessageScheduler& scheduler);
+void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageScheduler& scheduler);
 
 int main(int argc, char** argv) {
   QCoreApplication a(argc, argv);
@@ -20,15 +25,80 @@ int main(int argc, char** argv) {
   RosClientNode ros_node;
   config::configure_msg_types(ros_node);
 
+  MessageScheduler scheduler;
+
   if (config::direct_mode) {
     // Websocket server
     WsServer ws_server{config::direct_mode_port};
-    ws_server.connect_ros_node(ros_node);
+    connect_server(ws_server, ros_node, scheduler);
     return a.exec();
   } else {
     // Websocket client
     WsClient ws_client{QString::fromStdString(config::host_url)};
-    ws_client.connect_ros_node(ros_node);
+    connect_client(ws_client, ros_node, scheduler);
     return a.exec();
   }
+}
+
+void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageScheduler& scheduler) {
+  // schedule messages
+  QObject::connect(
+      &ros_node,
+      &RosClientNode::ros_message_encoded,
+      &scheduler,
+      &MessageScheduler::enqueue);
+  // update estimated bandwidth
+  QObject::connect(
+    &ws_client,
+    &WsClient::bandwidth_estimated,
+    &scheduler,
+    &MessageScheduler::set_bandwidth
+  );
+  // run scheduler
+  QObject::connect(
+    &ws_client,
+    &WsClient::network_unblocked,
+    &scheduler,
+    &MessageScheduler::schedule
+  );
+  // send scheduled message
+  QObject::connect(
+    &scheduler,
+    &MessageScheduler::scheduled,
+    [&ws_client](const QString& topic, const QByteArray& data){ws_client.send_message(data);}
+  );
+
+  // receive
+  QObject::connect(
+      &ws_client,
+      &WsClient::message_received,
+      &ros_node,
+      &RosClientNode::decode_net_message);
+
+  // startup
+  QObject::connect(
+      &ws_client,
+      &WsClient::connected,
+      &ros_node,
+      &RosClientNode::subscribe_remote_msgs);
+}
+
+void connect_server(WsServer& ws_server, RosClientNode& ros_node, MessageScheduler& scheduler) {
+  // send
+  // Need to use string-based connect to support default arg.
+  // https://doc.qt.io/qt-5/signalsandslots-syntaxes.html
+  // Trivial lambda-based version will not work because it is called from
+  // another thread.
+  QObject::connect(
+      &ros_node,
+      SIGNAL(ros_message_encoded(const QByteArray&)),
+      &ws_server,
+      SLOT(broadcast_message(const QByteArray&)));
+
+  // receive
+  QObject::connect(
+      &ws_server,
+      &WsServer::binary_message_received,
+      &ros_node,
+      &RosClientNode::decode_net_message);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,13 +47,6 @@ void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageSchedul
       &RosClientNode::ros_message_encoded,
       &scheduler,
       &MessageScheduler::enqueue);
-  // update estimated bandwidth
-  QObject::connect(
-    &ws_client,
-    &WsClient::bandwidth_estimated,
-    &scheduler,
-    &MessageScheduler::set_bandwidth
-  );
   // run scheduler
   QObject::connect(
     &ws_client,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,20 +1,22 @@
 #include <ros/ros.h>
 
-#include <QtCore/QCoreApplication>
 #include <QObject>
+#include <QtCore/QCoreApplication>
 #include <chrono>
 #include <cstdint>
 #include <iostream>
 #include <string>
 
+#include "MessageScheduler.hpp"
 #include "RosClientNode.hpp"
 #include "WsClient.hpp"
 #include "WsServer.hpp"
-#include "MessageScheduler.hpp"
 #include "config.hpp"
 
-void connect_server(WsServer& ws_server, RosClientNode& ros_node, MessageScheduler& scheduler);
-void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageScheduler& scheduler);
+void connect_server(
+    WsServer& ws_server, RosClientNode& ros_node, MessageScheduler& scheduler);
+void connect_client(
+    WsClient& ws_client, RosClientNode& ros_node, MessageScheduler& scheduler);
 
 int main(int argc, char** argv) {
   QCoreApplication a(argc, argv);
@@ -40,7 +42,8 @@ int main(int argc, char** argv) {
   }
 }
 
-void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageScheduler& scheduler) {
+void connect_client(
+    WsClient& ws_client, RosClientNode& ros_node, MessageScheduler& scheduler) {
   // schedule messages
   QObject::connect(
       &ros_node,
@@ -49,17 +52,15 @@ void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageSchedul
       &MessageScheduler::enqueue);
   // run scheduler
   QObject::connect(
-    &ws_client,
-    &WsClient::network_unblocked,
-    &scheduler,
-    &MessageScheduler::network_unblocked
-  );
+      &ws_client,
+      &WsClient::network_unblocked,
+      &scheduler,
+      &MessageScheduler::network_unblocked);
   // send scheduled message
   QObject::connect(
-    &scheduler,
-    &MessageScheduler::scheduled,
-    [&ws_client](const QByteArray& data){ws_client.send_message(data);}
-  );
+      &scheduler,
+      &MessageScheduler::scheduled,
+      [&ws_client](const QByteArray& data) { ws_client.send_message(data); });
 
   // receive
   QObject::connect(
@@ -76,7 +77,8 @@ void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageSchedul
       &RosClientNode::subscribe_remote_msgs);
 }
 
-void connect_server(WsServer& ws_server, RosClientNode& ros_node, MessageScheduler& scheduler) {
+void connect_server(
+    WsServer& ws_server, RosClientNode& ros_node, MessageScheduler& scheduler) {
   // send
   // Need to use string-based connect to support default arg.
   // https://doc.qt.io/qt-5/signalsandslots-syntaxes.html

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,7 +65,7 @@ void connect_client(WsClient& ws_client, RosClientNode& ros_node, MessageSchedul
   QObject::connect(
     &scheduler,
     &MessageScheduler::scheduled,
-    [&ws_client](const QString& topic, const QByteArray& data){ws_client.send_message(data);}
+    [&ws_client](const QByteArray& data){ws_client.send_message(data);}
   );
 
   // receive

--- a/src/topic_config.hpp
+++ b/src/topic_config.hpp
@@ -56,7 +56,7 @@ class BuilderProp {
 
 /**
  * @brief Config for sending messages from a local topic to Robofleet
- * 
+ *
  * This creates a ROS subscriber to bridge local messages to Robofleet.
  * @tparam RosType the ROS message class being sent on the topic
  */
@@ -81,7 +81,7 @@ struct SendLocalTopic {
 
 /**
  * @brief Config for receiving messages from a remote topic on Robofleet
- * 
+ *
  * This creates a ROS publisher to bridge remote messages to the robot.
  * @tparam RosType the ROS message class being sent on the topic
  */
@@ -95,4 +95,4 @@ struct ReceiveRemoteTopic {
     to.assert_set();
   }
 };
-};
+};  // namespace topic_config

--- a/src/topic_config.hpp
+++ b/src/topic_config.hpp
@@ -2,6 +2,7 @@
 #include <exception>
 #include <string>
 
+namespace topic_config {
 template <typename Builder, typename T>
 class BuilderProp {
   bool _set = false;
@@ -93,4 +94,5 @@ struct ReceiveRemoteTopic {
     from.assert_set();
     to.assert_set();
   }
+};
 };


### PR DESCRIPTION
This adds weighted fair message scheduling. Topics can now be assigned a `priority`, where a high priority will give them a larger share of network bandwidth. Topics for which messages shouldn't be dropped, such as Robofleet subscriptions or control messages, can be marked as `no_drop`. They will be queued and never dropped, and will be sent in FIFO fashion, before any other messages.

This also adds a new, more readable (I think) configuration syntax. Old configuration files are still compatible, but they won't support these new features.
 
This diff is pretty bad, maybe ignore the refactoring. I tested this against Robofleet and everything seems to be working. The scheduling algorithm is implemented in about 100 lines of code in MessageScheduler.hpp. You can see the new configuration syntax in config.example.hpp.

I also wrote [a big doc](https://gist.github.com/loganzartman/2b31bf4b286fce4eeba551c5a7697b84) about the motivation and rationale behind the scheduling algorithm.

Below is a demo with my bandwidth limited to 1mbps using 
`tc qdisc add dev wg0 root tbf rate 1mbit latency 100ms burst 1m`

No scheduler | With scheduler
:---:|:---:
![before_scheduler3](https://user-images.githubusercontent.com/3401573/98454233-dcfde500-2127-11eb-865d-cfed7c0af753.gif) | ![after_scheduler](https://user-images.githubusercontent.com/3401573/98454235-dec7a880-2127-11eb-87d8-fd2099bf7400.gif)
