### PR TITLE
Fix flatbuffers misuse in decode()

### DIFF
--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -176,7 +176,9 @@ class RosClientNode : public QObject {
       pub_fns[msg_type] = [this, full_to_topic](
                               const QByteArray& data,
                               const std::string& msg_type) {
-        const auto* root = flatbuffers::GetRoot<typename flatbuffers_type_for<T>::type>(data.data());
+        const auto* root =
+            flatbuffers::GetRoot<typename flatbuffers_type_for<T>::type>(
+                data.data());
         const T msg = decode<T>(root);
         publish_ros_msg<T>(msg, msg_type, full_to_topic);
       };

--- a/src/RosClientNode.hpp
+++ b/src/RosClientNode.hpp
@@ -176,7 +176,8 @@ class RosClientNode : public QObject {
       pub_fns[msg_type] = [this, full_to_topic](
                               const QByteArray& data,
                               const std::string& msg_type) {
-        const T msg = decode<T>(data.data());
+        const auto* root = flatbuffers::GetRoot<typename flatbuffers_type_for<T>::type>(data.data());
+        const T msg = decode<T>(root);
         publish_ros_msg<T>(msg, msg_type, full_to_topic);
       };
     }

--- a/src/decode.hpp
+++ b/src/decode.hpp
@@ -22,18 +22,19 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <std_msgs/String.h>
 
-// to add a new message type, specialize this template to decode the message and...
+// to add a new message type, specialize this template to decode the message
+// and...
 template <typename Dst, typename Src>
 static Dst decode(const Src* const src);
 // specialize this struct to map ROS types to Flatbuffers types
 template <typename RosType>
-struct flatbuffers_type_for {typedef void type;};
-
+struct flatbuffers_type_for {
+  typedef void type;
+};
 
 // *** utility functions ***
 template <typename T, typename Vsrc, typename Vdst>
-static void decode_vector(
-    const Vsrc* const src_vector_ptr, Vdst& dst_vector) {
+static void decode_vector(const Vsrc* const src_vector_ptr, Vdst& dst_vector) {
   dst_vector.resize(src_vector_ptr->size());
   auto src = src_vector_ptr->begin();
   auto dst = dst_vector.begin();
@@ -45,11 +46,12 @@ static void decode_vector(
   }
 }
 
-
 // *** specializations below ***
 
 template <>
-struct flatbuffers_type_for<std_msgs::Header> {typedef fb::std_msgs::Header type;};
+struct flatbuffers_type_for<std_msgs::Header> {
+  typedef fb::std_msgs::Header type;
+};
 template <>
 std_msgs::Header decode(const fb::std_msgs::Header* const src) {
   std_msgs::Header dst;
@@ -61,7 +63,9 @@ std_msgs::Header decode(const fb::std_msgs::Header* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<std_msgs::String> {typedef fb::std_msgs::String type;};
+struct flatbuffers_type_for<std_msgs::String> {
+  typedef fb::std_msgs::String type;
+};
 template <>
 std_msgs::String decode(const fb::std_msgs::String* const src) {
   std_msgs::String dst;
@@ -70,9 +74,12 @@ std_msgs::String decode(const fb::std_msgs::String* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::RobofleetStatus> {typedef fb::amrl_msgs::RobofleetStatus type;};
+struct flatbuffers_type_for<amrl_msgs::RobofleetStatus> {
+  typedef fb::amrl_msgs::RobofleetStatus type;
+};
 template <>
-amrl_msgs::RobofleetStatus decode(const fb::amrl_msgs::RobofleetStatus* const src) {
+amrl_msgs::RobofleetStatus decode(
+    const fb::amrl_msgs::RobofleetStatus* const src) {
   amrl_msgs::RobofleetStatus dst;
   dst.battery_level = src->battery_level();
   dst.is_ok = src->is_ok();
@@ -82,9 +89,12 @@ amrl_msgs::RobofleetStatus decode(const fb::amrl_msgs::RobofleetStatus* const sr
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::RobofleetSubscription> {typedef fb::amrl_msgs::RobofleetSubscription type;};
+struct flatbuffers_type_for<amrl_msgs::RobofleetSubscription> {
+  typedef fb::amrl_msgs::RobofleetSubscription type;
+};
 template <>
-amrl_msgs::RobofleetSubscription decode(const fb::amrl_msgs::RobofleetSubscription* const src) {
+amrl_msgs::RobofleetSubscription decode(
+    const fb::amrl_msgs::RobofleetSubscription* const src) {
   amrl_msgs::RobofleetSubscription dst;
   dst.action = src->action();
   dst.topic_regex = src->topic_regex()->str();
@@ -92,7 +102,9 @@ amrl_msgs::RobofleetSubscription decode(const fb::amrl_msgs::RobofleetSubscripti
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::Point2D> {typedef fb::amrl_msgs::Point2D type;};
+struct flatbuffers_type_for<amrl_msgs::Point2D> {
+  typedef fb::amrl_msgs::Point2D type;
+};
 template <>
 amrl_msgs::Point2D decode(const fb::amrl_msgs::Point2D* const src) {
   amrl_msgs::Point2D dst;
@@ -103,7 +115,9 @@ amrl_msgs::Point2D decode(const fb::amrl_msgs::Point2D* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::Pose2Df> {typedef fb::amrl_msgs::Pose2Df type;};
+struct flatbuffers_type_for<amrl_msgs::Pose2Df> {
+  typedef fb::amrl_msgs::Pose2Df type;
+};
 template <>
 amrl_msgs::Pose2Df decode(const fb::amrl_msgs::Pose2Df* const src) {
   amrl_msgs::Pose2Df dst;
@@ -115,7 +129,9 @@ amrl_msgs::Pose2Df decode(const fb::amrl_msgs::Pose2Df* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::ColoredArc2D> {typedef fb::amrl_msgs::ColoredArc2D type;};
+struct flatbuffers_type_for<amrl_msgs::ColoredArc2D> {
+  typedef fb::amrl_msgs::ColoredArc2D type;
+};
 template <>
 amrl_msgs::ColoredArc2D decode(const fb::amrl_msgs::ColoredArc2D* const src) {
   amrl_msgs::ColoredArc2D dst;
@@ -129,7 +145,9 @@ amrl_msgs::ColoredArc2D decode(const fb::amrl_msgs::ColoredArc2D* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::ColoredLine2D> {typedef fb::amrl_msgs::ColoredLine2D type;};
+struct flatbuffers_type_for<amrl_msgs::ColoredLine2D> {
+  typedef fb::amrl_msgs::ColoredLine2D type;
+};
 template <>
 amrl_msgs::ColoredLine2D decode(const fb::amrl_msgs::ColoredLine2D* const src) {
   amrl_msgs::ColoredLine2D dst;
@@ -141,9 +159,12 @@ amrl_msgs::ColoredLine2D decode(const fb::amrl_msgs::ColoredLine2D* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::ColoredPoint2D> {typedef fb::amrl_msgs::ColoredPoint2D type;};
+struct flatbuffers_type_for<amrl_msgs::ColoredPoint2D> {
+  typedef fb::amrl_msgs::ColoredPoint2D type;
+};
 template <>
-amrl_msgs::ColoredPoint2D decode(const fb::amrl_msgs::ColoredPoint2D* const src) {
+amrl_msgs::ColoredPoint2D decode(
+    const fb::amrl_msgs::ColoredPoint2D* const src) {
   amrl_msgs::ColoredPoint2D dst;
 
   dst.color = src->color();
@@ -152,9 +173,12 @@ amrl_msgs::ColoredPoint2D decode(const fb::amrl_msgs::ColoredPoint2D* const src)
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::PathVisualization> {typedef fb::amrl_msgs::PathVisualization type;};
+struct flatbuffers_type_for<amrl_msgs::PathVisualization> {
+  typedef fb::amrl_msgs::PathVisualization type;
+};
 template <>
-amrl_msgs::PathVisualization decode(const fb::amrl_msgs::PathVisualization* const src) {
+amrl_msgs::PathVisualization decode(
+    const fb::amrl_msgs::PathVisualization* const src) {
   amrl_msgs::PathVisualization dst;
 
   dst.clearance = src->clearance();
@@ -164,9 +188,12 @@ amrl_msgs::PathVisualization decode(const fb::amrl_msgs::PathVisualization* cons
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::VisualizationMsg> {typedef fb::amrl_msgs::VisualizationMsg type;};
+struct flatbuffers_type_for<amrl_msgs::VisualizationMsg> {
+  typedef fb::amrl_msgs::VisualizationMsg type;
+};
 template <>
-amrl_msgs::VisualizationMsg decode(const fb::amrl_msgs::VisualizationMsg* const src) {
+amrl_msgs::VisualizationMsg decode(
+    const fb::amrl_msgs::VisualizationMsg* const src) {
   amrl_msgs::VisualizationMsg dst;
   dst.header = decode<std_msgs::Header>(src->header());
 
@@ -181,9 +208,12 @@ amrl_msgs::VisualizationMsg decode(const fb::amrl_msgs::VisualizationMsg* const 
 }
 
 template <>
-struct flatbuffers_type_for<amrl_msgs::Localization2DMsg> {typedef fb::amrl_msgs::Localization2DMsg type;};
+struct flatbuffers_type_for<amrl_msgs::Localization2DMsg> {
+  typedef fb::amrl_msgs::Localization2DMsg type;
+};
 template <>
-amrl_msgs::Localization2DMsg decode(const fb::amrl_msgs::Localization2DMsg* const src) {
+amrl_msgs::Localization2DMsg decode(
+    const fb::amrl_msgs::Localization2DMsg* const src) {
   amrl_msgs::Localization2DMsg dst;
   dst.header = decode<std_msgs::Header>(src->header());
   dst.map = src->map()->str();
@@ -194,9 +224,12 @@ amrl_msgs::Localization2DMsg decode(const fb::amrl_msgs::Localization2DMsg* cons
 }
 
 template <>
-struct flatbuffers_type_for<geometry_msgs::PoseStamped> {typedef fb::geometry_msgs::PoseStamped type;};
+struct flatbuffers_type_for<geometry_msgs::PoseStamped> {
+  typedef fb::geometry_msgs::PoseStamped type;
+};
 template <>
-geometry_msgs::PoseStamped decode(const fb::geometry_msgs::PoseStamped* const src) {
+geometry_msgs::PoseStamped decode(
+    const fb::geometry_msgs::PoseStamped* const src) {
   geometry_msgs::PoseStamped dst;
 
   dst.header = decode<std_msgs::Header>(src->header());
@@ -213,7 +246,9 @@ geometry_msgs::PoseStamped decode(const fb::geometry_msgs::PoseStamped* const sr
 }
 
 template <>
-struct flatbuffers_type_for<nav_msgs::Odometry> {typedef fb::nav_msgs::Odometry type;};
+struct flatbuffers_type_for<nav_msgs::Odometry> {
+  typedef fb::nav_msgs::Odometry type;
+};
 template <>
 nav_msgs::Odometry decode(const fb::nav_msgs::Odometry* const src) {
   nav_msgs::Odometry dst;
@@ -247,7 +282,9 @@ nav_msgs::Odometry decode(const fb::nav_msgs::Odometry* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<sensor_msgs::LaserScan> {typedef fb::sensor_msgs::LaserScan type;};
+struct flatbuffers_type_for<sensor_msgs::LaserScan> {
+  typedef fb::sensor_msgs::LaserScan type;
+};
 template <>
 sensor_msgs::LaserScan decode(const fb::sensor_msgs::LaserScan* const src) {
   sensor_msgs::LaserScan dst;
@@ -270,7 +307,9 @@ sensor_msgs::LaserScan decode(const fb::sensor_msgs::LaserScan* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<sensor_msgs::NavSatFix> {typedef fb::sensor_msgs::NavSatFix type;};
+struct flatbuffers_type_for<sensor_msgs::NavSatFix> {
+  typedef fb::sensor_msgs::NavSatFix type;
+};
 template <>
 sensor_msgs::NavSatFix decode(const fb::sensor_msgs::NavSatFix* const src) {
   sensor_msgs::NavSatFix dst;
@@ -285,9 +324,12 @@ sensor_msgs::NavSatFix decode(const fb::sensor_msgs::NavSatFix* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<sensor_msgs::CompressedImage> {typedef fb::sensor_msgs::CompressedImage type;};
+struct flatbuffers_type_for<sensor_msgs::CompressedImage> {
+  typedef fb::sensor_msgs::CompressedImage type;
+};
 template <>
-sensor_msgs::CompressedImage decode(const fb::sensor_msgs::CompressedImage* const src) {
+sensor_msgs::CompressedImage decode(
+    const fb::sensor_msgs::CompressedImage* const src) {
   sensor_msgs::CompressedImage dst;
   dst.header = decode<std_msgs::Header>(src->header());
   dst.data.resize(src->data()->size());
@@ -297,7 +339,9 @@ sensor_msgs::CompressedImage decode(const fb::sensor_msgs::CompressedImage* cons
 }
 
 template <>
-struct flatbuffers_type_for<sensor_msgs::PointField> {typedef fb::sensor_msgs::PointField type;};
+struct flatbuffers_type_for<sensor_msgs::PointField> {
+  typedef fb::sensor_msgs::PointField type;
+};
 template <>
 sensor_msgs::PointField decode(const fb::sensor_msgs::PointField* const src) {
   sensor_msgs::PointField dst;
@@ -309,7 +353,9 @@ sensor_msgs::PointField decode(const fb::sensor_msgs::PointField* const src) {
 }
 
 template <>
-struct flatbuffers_type_for<sensor_msgs::PointCloud2> {typedef fb::sensor_msgs::PointCloud2 type;};
+struct flatbuffers_type_for<sensor_msgs::PointCloud2> {
+  typedef fb::sensor_msgs::PointCloud2 type;
+};
 template <>
 sensor_msgs::PointCloud2 decode(const fb::sensor_msgs::PointCloud2* const src) {
   sensor_msgs::PointCloud2 dst;

--- a/src/decode.hpp
+++ b/src/decode.hpp
@@ -22,71 +22,57 @@
 #include <sensor_msgs/PointCloud2.h>
 #include <std_msgs/String.h>
 
-// to add a new message type, specialize this template to decode the message
-template <typename T>
-static T decode(const void* const data);
+// to add a new message type, specialize this template to decode the message and...
+template <typename Dst, typename Src>
+static Dst decode(const Src* const src);
+// specialize this struct to map ROS types to Flatbuffers types
+template <typename RosType>
+struct flatbuffers_type_for {typedef void type;};
+
 
 // *** utility functions ***
-/**
- * @brief Copy the ROS header from a flatbuffers Object API object src to a
- * ROS class object dst.
- *
- * @tparam Tsrc a generated flatbuffers Object API type
- * @tparam Tdst a ROS class type
- * @param src source
- * @param dst destination
- */
-template <typename Tsrc, typename Tdst>
-static void decode_header(const Tsrc& src, Tdst& dst) {
-  dst.header.frame_id = src->header()->frame_id()->str();
-  dst.header.seq = src->header()->seq();
-  dst.header.stamp = ros::Time(
-      src->header()->stamp()->secs(), src->header()->stamp()->nsecs());
-}
-
-/**
- * @brief Given a flatbuffers Object API object and a target ROS class type T,
- * call the decode<T>() function on the object's data.
- *
- * @tparam T target ROS class type
- * @tparam O a generated flatbuffers Object API type
- * @param src the flatbuffers object to decode
- * @return T the result of calling decode<T>() on src's data
- */
-template <typename T, typename O>
-static T decode_obj(const O* const src) {
-  return decode<T>(flatbuffers::GetBufferStartFromRootPointer(src));
-}
-
 template <typename T, typename Vsrc, typename Vdst>
-static void decode_obj_vector(
+static void decode_vector(
     const Vsrc* const src_vector_ptr, Vdst& dst_vector) {
   dst_vector.resize(src_vector_ptr->size());
   auto src = src_vector_ptr->begin();
   auto dst = dst_vector.begin();
 
   while (src != src_vector_ptr->end()) {
-    *dst = decode_obj<T>(*src);
+    *dst = decode<T>(*src);
     ++src;
     ++dst;
   }
 }
 
+
 // *** specializations below ***
 
 template <>
-std_msgs::String decode(const void* const data) {
-  const fb::std_msgs::String* src =
-      flatbuffers::GetRoot<fb::std_msgs::String>(data);
+struct flatbuffers_type_for<std_msgs::Header> {typedef fb::std_msgs::Header type;};
+template <>
+std_msgs::Header decode(const fb::std_msgs::Header* const src) {
+  std_msgs::Header dst;
+
+  dst.frame_id = src->frame_id()->str();
+  dst.seq = src->seq();
+  dst.stamp = ros::Time(src->stamp()->secs(), src->stamp()->nsecs());
+  return dst;
+}
+
+template <>
+struct flatbuffers_type_for<std_msgs::String> {typedef fb::std_msgs::String type;};
+template <>
+std_msgs::String decode(const fb::std_msgs::String* const src) {
   std_msgs::String dst;
   dst.data = src->data()->str();
   return dst;
 }
 
 template <>
-amrl_msgs::RobofleetStatus decode(const void* const data) {
-  const fb::amrl_msgs::RobofleetStatus* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::RobofleetStatus>(data);
+struct flatbuffers_type_for<amrl_msgs::RobofleetStatus> {typedef fb::amrl_msgs::RobofleetStatus type;};
+template <>
+amrl_msgs::RobofleetStatus decode(const fb::amrl_msgs::RobofleetStatus* const src) {
   amrl_msgs::RobofleetStatus dst;
   dst.battery_level = src->battery_level();
   dst.is_ok = src->is_ok();
@@ -96,9 +82,9 @@ amrl_msgs::RobofleetStatus decode(const void* const data) {
 }
 
 template <>
-amrl_msgs::RobofleetSubscription decode(const void* const data) {
-  const fb::amrl_msgs::RobofleetSubscription* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::RobofleetSubscription>(data);
+struct flatbuffers_type_for<amrl_msgs::RobofleetSubscription> {typedef fb::amrl_msgs::RobofleetSubscription type;};
+template <>
+amrl_msgs::RobofleetSubscription decode(const fb::amrl_msgs::RobofleetSubscription* const src) {
   amrl_msgs::RobofleetSubscription dst;
   dst.action = src->action();
   dst.topic_regex = src->topic_regex()->str();
@@ -106,9 +92,9 @@ amrl_msgs::RobofleetSubscription decode(const void* const data) {
 }
 
 template <>
-amrl_msgs::Point2D decode(const void* const data) {
-  const fb::amrl_msgs::Point2D* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::Point2D>(data);
+struct flatbuffers_type_for<amrl_msgs::Point2D> {typedef fb::amrl_msgs::Point2D type;};
+template <>
+amrl_msgs::Point2D decode(const fb::amrl_msgs::Point2D* const src) {
   amrl_msgs::Point2D dst;
 
   dst.x = src->x();
@@ -117,9 +103,9 @@ amrl_msgs::Point2D decode(const void* const data) {
 }
 
 template <>
-amrl_msgs::Pose2Df decode(const void* const data) {
-  const fb::amrl_msgs::Pose2Df* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::Pose2Df>(data);
+struct flatbuffers_type_for<amrl_msgs::Pose2Df> {typedef fb::amrl_msgs::Pose2Df type;};
+template <>
+amrl_msgs::Pose2Df decode(const fb::amrl_msgs::Pose2Df* const src) {
   amrl_msgs::Pose2Df dst;
 
   dst.theta = src->theta();
@@ -129,12 +115,12 @@ amrl_msgs::Pose2Df decode(const void* const data) {
 }
 
 template <>
-amrl_msgs::ColoredArc2D decode(const void* const data) {
-  const fb::amrl_msgs::ColoredArc2D* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::ColoredArc2D>(data);
+struct flatbuffers_type_for<amrl_msgs::ColoredArc2D> {typedef fb::amrl_msgs::ColoredArc2D type;};
+template <>
+amrl_msgs::ColoredArc2D decode(const fb::amrl_msgs::ColoredArc2D* const src) {
   amrl_msgs::ColoredArc2D dst;
 
-  dst.center = decode_obj<amrl_msgs::Point2D>(src->center());
+  dst.center = decode<amrl_msgs::Point2D>(src->center());
   dst.color = src->color();
   dst.end_angle = src->end_angle();
   dst.radius = src->radius();
@@ -143,32 +129,32 @@ amrl_msgs::ColoredArc2D decode(const void* const data) {
 }
 
 template <>
-amrl_msgs::ColoredLine2D decode(const void* const data) {
-  const fb::amrl_msgs::ColoredLine2D* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::ColoredLine2D>(data);
+struct flatbuffers_type_for<amrl_msgs::ColoredLine2D> {typedef fb::amrl_msgs::ColoredLine2D type;};
+template <>
+amrl_msgs::ColoredLine2D decode(const fb::amrl_msgs::ColoredLine2D* const src) {
   amrl_msgs::ColoredLine2D dst;
 
   dst.color = src->color();
-  dst.p0 = decode_obj<amrl_msgs::Point2D>(src->p0());
-  dst.p1 = decode_obj<amrl_msgs::Point2D>(src->p1());
+  dst.p0 = decode<amrl_msgs::Point2D>(src->p0());
+  dst.p1 = decode<amrl_msgs::Point2D>(src->p1());
   return dst;
 }
 
 template <>
-amrl_msgs::ColoredPoint2D decode(const void* const data) {
-  const fb::amrl_msgs::ColoredPoint2D* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::ColoredPoint2D>(data);
+struct flatbuffers_type_for<amrl_msgs::ColoredPoint2D> {typedef fb::amrl_msgs::ColoredPoint2D type;};
+template <>
+amrl_msgs::ColoredPoint2D decode(const fb::amrl_msgs::ColoredPoint2D* const src) {
   amrl_msgs::ColoredPoint2D dst;
 
   dst.color = src->color();
-  dst.point = decode_obj<amrl_msgs::Point2D>(src->point());
+  dst.point = decode<amrl_msgs::Point2D>(src->point());
   return dst;
 }
 
 template <>
-amrl_msgs::PathVisualization decode(const void* const data) {
-  const fb::amrl_msgs::PathVisualization* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::PathVisualization>(data);
+struct flatbuffers_type_for<amrl_msgs::PathVisualization> {typedef fb::amrl_msgs::PathVisualization type;};
+template <>
+amrl_msgs::PathVisualization decode(const fb::amrl_msgs::PathVisualization* const src) {
   amrl_msgs::PathVisualization dst;
 
   dst.clearance = src->clearance();
@@ -178,28 +164,28 @@ amrl_msgs::PathVisualization decode(const void* const data) {
 }
 
 template <>
-amrl_msgs::VisualizationMsg decode(const void* const data) {
-  const fb::amrl_msgs::VisualizationMsg* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::VisualizationMsg>(data);
+struct flatbuffers_type_for<amrl_msgs::VisualizationMsg> {typedef fb::amrl_msgs::VisualizationMsg type;};
+template <>
+amrl_msgs::VisualizationMsg decode(const fb::amrl_msgs::VisualizationMsg* const src) {
   amrl_msgs::VisualizationMsg dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
 
   dst.ns = src->ns()->str();
-  decode_obj_vector<amrl_msgs::ColoredArc2D>(src->arcs(), dst.arcs);
-  decode_obj_vector<amrl_msgs::ColoredLine2D>(src->lines(), dst.lines);
-  decode_obj_vector<amrl_msgs::PathVisualization>(
+  decode_vector<amrl_msgs::ColoredArc2D>(src->arcs(), dst.arcs);
+  decode_vector<amrl_msgs::ColoredLine2D>(src->lines(), dst.lines);
+  decode_vector<amrl_msgs::PathVisualization>(
       src->path_options(), dst.path_options);
-  decode_obj_vector<amrl_msgs::Pose2Df>(src->particles(), dst.particles);
-  decode_obj_vector<amrl_msgs::ColoredPoint2D>(src->points(), dst.points);
+  decode_vector<amrl_msgs::Pose2Df>(src->particles(), dst.particles);
+  decode_vector<amrl_msgs::ColoredPoint2D>(src->points(), dst.points);
   return dst;
 }
 
 template <>
-amrl_msgs::Localization2DMsg decode(const void* const data) {
-  const fb::amrl_msgs::Localization2DMsg* src =
-      flatbuffers::GetRoot<fb::amrl_msgs::Localization2DMsg>(data);
+struct flatbuffers_type_for<amrl_msgs::Localization2DMsg> {typedef fb::amrl_msgs::Localization2DMsg type;};
+template <>
+amrl_msgs::Localization2DMsg decode(const fb::amrl_msgs::Localization2DMsg* const src) {
   amrl_msgs::Localization2DMsg dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
   dst.map = src->map()->str();
   dst.pose.x = src->pose()->x();
   dst.pose.y = src->pose()->y();
@@ -208,12 +194,12 @@ amrl_msgs::Localization2DMsg decode(const void* const data) {
 }
 
 template <>
-geometry_msgs::PoseStamped decode(const void* const data) {
-  const fb::geometry_msgs::PoseStamped* src =
-      flatbuffers::GetRoot<fb::geometry_msgs::PoseStamped>(data);
+struct flatbuffers_type_for<geometry_msgs::PoseStamped> {typedef fb::geometry_msgs::PoseStamped type;};
+template <>
+geometry_msgs::PoseStamped decode(const fb::geometry_msgs::PoseStamped* const src) {
   geometry_msgs::PoseStamped dst;
 
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
 
   dst.pose.orientation.x = src->pose()->orientation()->x();
   dst.pose.orientation.y = src->pose()->orientation()->y();
@@ -227,11 +213,11 @@ geometry_msgs::PoseStamped decode(const void* const data) {
 }
 
 template <>
-nav_msgs::Odometry decode(const void* const data) {
-  const fb::nav_msgs::Odometry* src =
-      flatbuffers::GetRoot<fb::nav_msgs::Odometry>(data);
+struct flatbuffers_type_for<nav_msgs::Odometry> {typedef fb::nav_msgs::Odometry type;};
+template <>
+nav_msgs::Odometry decode(const fb::nav_msgs::Odometry* const src) {
   nav_msgs::Odometry dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
 
   dst.child_frame_id = src->child_frame_id()->str();
 
@@ -261,11 +247,11 @@ nav_msgs::Odometry decode(const void* const data) {
 }
 
 template <>
-sensor_msgs::LaserScan decode(const void* const data) {
-  const fb::sensor_msgs::LaserScan* src =
-      flatbuffers::GetRoot<fb::sensor_msgs::LaserScan>(data);
+struct flatbuffers_type_for<sensor_msgs::LaserScan> {typedef fb::sensor_msgs::LaserScan type;};
+template <>
+sensor_msgs::LaserScan decode(const fb::sensor_msgs::LaserScan* const src) {
   sensor_msgs::LaserScan dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
   dst.angle_increment = src->angle_increment();
   dst.angle_max = src->angle_max();
   dst.angle_min = src->angle_min();
@@ -284,11 +270,11 @@ sensor_msgs::LaserScan decode(const void* const data) {
 }
 
 template <>
-sensor_msgs::NavSatFix decode(const void* const data) {
-  const fb::sensor_msgs::NavSatFix* src =
-      flatbuffers::GetRoot<fb::sensor_msgs::NavSatFix>(data);
+struct flatbuffers_type_for<sensor_msgs::NavSatFix> {typedef fb::sensor_msgs::NavSatFix type;};
+template <>
+sensor_msgs::NavSatFix decode(const fb::sensor_msgs::NavSatFix* const src) {
   sensor_msgs::NavSatFix dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
   dst.altitude = src->altitude();
   dst.latitude = src->latitude();
   dst.longitude = src->longitude();
@@ -299,11 +285,11 @@ sensor_msgs::NavSatFix decode(const void* const data) {
 }
 
 template <>
-sensor_msgs::CompressedImage decode(const void* const data) {
-  const fb::sensor_msgs::CompressedImage* src =
-      flatbuffers::GetRoot<fb::sensor_msgs::CompressedImage>(data);
+struct flatbuffers_type_for<sensor_msgs::CompressedImage> {typedef fb::sensor_msgs::CompressedImage type;};
+template <>
+sensor_msgs::CompressedImage decode(const fb::sensor_msgs::CompressedImage* const src) {
   sensor_msgs::CompressedImage dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
   dst.data.resize(src->data()->size());
   std::copy(src->data()->begin(), src->data()->end(), dst.data.begin());
   dst.format = src->format()->str();
@@ -311,9 +297,9 @@ sensor_msgs::CompressedImage decode(const void* const data) {
 }
 
 template <>
-sensor_msgs::PointField decode(const void* const data) {
-  const fb::sensor_msgs::PointField* src =
-      flatbuffers::GetRoot<fb::sensor_msgs::PointField>(data);
+struct flatbuffers_type_for<sensor_msgs::PointField> {typedef fb::sensor_msgs::PointField type;};
+template <>
+sensor_msgs::PointField decode(const fb::sensor_msgs::PointField* const src) {
   sensor_msgs::PointField dst;
   dst.count = src->count();
   dst.name = src->name()->str();
@@ -323,31 +309,19 @@ sensor_msgs::PointField decode(const void* const data) {
 }
 
 template <>
-sensor_msgs::PointCloud2 decode(const void* const data) {
-  const fb::sensor_msgs::PointCloud2* src =
-      flatbuffers::GetRoot<fb::sensor_msgs::PointCloud2>(data);
+struct flatbuffers_type_for<sensor_msgs::PointCloud2> {typedef fb::sensor_msgs::PointCloud2 type;};
+template <>
+sensor_msgs::PointCloud2 decode(const fb::sensor_msgs::PointCloud2* const src) {
   sensor_msgs::PointCloud2 dst;
-  decode_header(src, dst);
+  dst.header = decode<std_msgs::Header>(src->header());
   dst.data.resize(src->data()->size());
   std::copy(src->data()->begin(), src->data()->end(), dst.data.begin());
-  decode_obj_vector<sensor_msgs::PointField>(src->fields(), dst.fields);
+  decode_vector<sensor_msgs::PointField>(src->fields(), dst.fields);
   dst.height = src->height();
   dst.width = src->width();
   dst.is_bigendian = src->is_bigendian();
   dst.is_dense = src->is_dense();
   dst.row_step = src->row_step();
   dst.point_step = src->point_step();
-  return dst;
-}
-
-template <>
-std_msgs::Header decode(const void* const data) {
-  const fb::std_msgs::Header* src =
-      flatbuffers::GetRoot<fb::std_msgs::Header>(data);
-  std_msgs::Header dst;
-
-  dst.frame_id = src->frame_id()->str();
-  dst.seq = src->seq();
-  dst.stamp = ros::Time(src->stamp()->secs(), src->stamp()->nsecs());
   return dst;
 }

--- a/test/decode.hpp
+++ b/test/decode.hpp
@@ -21,7 +21,7 @@ TEST(DecodeObjectTest, HandlesStdHeader) {
   encode_std_header(fbb);
 
   const fb::std_msgs::Header* encoded = flatbuffers::GetRoot<fb::std_msgs::Header>(fbb.GetBufferPointer());
-  const std_msgs::Header decoded = decode_obj<std_msgs::Header>(encoded);
+  const std_msgs::Header decoded = decode<std_msgs::Header>(encoded);
 
   EXPECT_EQ(decoded.frame_id, "frame");
   EXPECT_EQ(decoded.seq, 100);

--- a/test/integration/encode_decode.hpp
+++ b/test/integration/encode_decode.hpp
@@ -22,6 +22,13 @@ TEST(EncodeDecode, PointCloud2) {
   src_field1.offset = 1;
   src.fields.push_back(src_field1);
 
+  sensor_msgs::PointField src_field2;
+  src_field1.count = 60;
+  src_field1.datatype = sensor_msgs::PointField::UINT32;
+  src_field1.name = "test2";
+  src_field1.offset = 2;
+  src.fields.push_back(src_field2);
+
   src.data.insert(src.data.end(), {1u, 2u, 4u, 8u, 16u});
 
   // encode

--- a/test/integration/encode_decode.hpp
+++ b/test/integration/encode_decode.hpp
@@ -37,7 +37,8 @@ TEST(EncodeDecode, PointCloud2) {
   fbb.Finish(flatbuffers::Offset<void>(encoded_offset));
 
   // decode
-  const sensor_msgs::PointCloud2 decoded = decode<sensor_msgs::PointCloud2>(fbb.GetBufferPointer());
+  const fb::sensor_msgs::PointCloud2* root = flatbuffers::GetRoot<typename flatbuffers_type_for<sensor_msgs::PointCloud2>::type>(fbb.GetBufferPointer());
+  const sensor_msgs::PointCloud2 decoded = decode<sensor_msgs::PointCloud2>(root);
 
   EXPECT_EQ(src, decoded);
 }


### PR DESCRIPTION
When decoding a vector with multiple items, we saw a failure here:
https://github.com/ut-amrl/robofleet_client/blob/master/include/flatbuffers/flatbuffers.h#L2574-L2578

After a lot of debugging and poking around the flatbuffers API, I'm not 100% sure why this is, but it might just not be valid to call this on individual elements of a flatbuffers vector.

Regardless, I've reworked `decode<T>()` to accept a Flatbuffers object pointer, rather than a raw `void*`. `RosClientNode` now needs to come up with those, so I've added some template mess to convert from a ROS class to a Flatbuffers class so that `RosClientNode` can call `flatbuffers::GetRoot<T>()` on its own.

I'd _really_ like to just get rid of all of this, and use ROS message introspection to dynamically encode to flexbuffers instead.