### PR TITLE
Added Qt5 websockets dependency to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * CMake
 * ROS Melodic
 * Qt5 >= 5.5
+* libqt5websockets5-dev
 
 ## Configuration
 


### PR DESCRIPTION
without 
$ sudo apt install libqt5websockets5-dev
I can't run make on the package in ros, even with Qt5 installed