### PR TITLE
move rate limiting logic to the MessageSchedulerLib

### DIFF
--- a/src/MessageScheduler.hpp
+++ b/src/MessageScheduler.hpp
@@ -41,9 +41,9 @@ class MessageScheduler : public QObject {
 
  public Q_SLOTS:
   void enqueue(
-      const QString& topic, const QByteArray& data, double priority,
+      const QString& topic, const QByteArray& data, double priority, double rate_limit,
       bool no_drop) {
-    ms->enqueue(topic.toUtf8().constData(), data, priority, no_drop);
+    ms->enqueue(topic.toUtf8().constData(), data, priority, rate_limit, no_drop);
   }
 
   /**


### PR DESCRIPTION
Separating robofleet client into a lib and a wrapper is nice, but things were a bit entangled with rate limiting. This moves all the rate limiting, scheduling, etc. logic into the lib side of things. However, I will point out this means we *do* pay the cost of encoding all the messages, even those that won't get sent quite yet because of rate limiting. I think this is ok because it's not too much cost, and also it allows us to queue up messages immediately, which helps in in case the rate limit timing is off from the publication timing in a way that would otherwise leave some dead space