### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/google/googletest
 [submodule "robofleet_client_lib"]
 	path = robofleet_client_lib
-	url = git@github.com:ut-amrl/robofleet_client_lib.git
+	url = https://github.com/ut-amrl/robofleet_client_lib


### PR DESCRIPTION
Users cannot install submodules with a git address.  changed robofleet_client_lib to an http address.  is that acceptable?